### PR TITLE
Set OpenAPI version to 3.0.0, don't use proto names for marshalling

### DIFF
--- a/example/bookstore/v1/bookstore.pb.bookstore_service.oas31.yaml
+++ b/example/bookstore/v1/bookstore.pb.bookstore_service.oas31.yaml
@@ -172,7 +172,7 @@ info:
     This is an auto-generated API for bookstore.v1.BookstoreService.
   title: API For bookstore.v1.BookstoreService
   version: 0.0.1
-openapi: 3.0.0
+openapi: 3.0.3
 paths:
   /authors/{author}:
     get:
@@ -194,7 +194,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/bookstore.v1.GetAuthorResponse'
-          description: Succesful response
+          description: Successful response
   /shelf:
     post:
       description: |2
@@ -211,7 +211,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/bookstore.v1.CreateShelfResponse'
-          description: Succesful response
+          description: Successful response
   /shelves:
     get:
       description: |2
@@ -250,7 +250,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/bookstore.v1.DeleteShelfResponse'
-          description: Succesful response
+          description: Successful response
   /shelves/{shelf}/books:
     post:
       description: |2
@@ -276,7 +276,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/bookstore.v1.CreateBookResponse'
-          description: Succesful response
+          description: Successful response
   /shelves/{shelf}/books/{book.id}:
     patch:
       description: Invokes the bookstore.v1.BookstoreService.UpdateBook method.
@@ -309,7 +309,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/bookstore.v1.UpdateBookResponse'
-          description: Succesful response
+          description: Successful response
   /shelves/{shelf}/books/{book}:
     delete:
       description: |2
@@ -343,7 +343,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/bookstore.v1.DeleteBookResponse'
-          description: Succesful response
+          description: Successful response
     get:
       description: |2
          Returns a specific book.
@@ -376,7 +376,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/bookstore.v1.GetBookResponse'
-          description: Succesful response
+          description: Successful response
 servers:
   - description: The server for bookstore.v1.BookstoreService.
     url: /

--- a/example/bookstore/v1/bookstore.pb.bookstore_service.oas31.yaml
+++ b/example/bookstore/v1/bookstore.pb.bookstore_service.oas31.yaml
@@ -172,7 +172,7 @@ info:
     This is an auto-generated API for bookstore.v1.BookstoreService.
   title: API For bookstore.v1.BookstoreService
   version: 0.0.1
-openapi: 3.1.0
+openapi: 3.0.0
 paths:
   /authors/{author}:
     get:

--- a/internal/apigw/apigw_openapi.go
+++ b/internal/apigw/apigw_openapi.go
@@ -75,7 +75,7 @@ func (module *Module) buildOperation(ctx pgsgo.Context, method pgs.Method, mt *m
 	outObj := method.Output()
 	outDescription := outObj.SourceCodeInfo().LeadingComments()
 	if outDescription == "" {
-		outDescription = "Succesful response"
+		outDescription = "Successful response"
 	}
 
 	methodDescription := method.SourceCodeInfo().LeadingComments()

--- a/internal/apigw/apigw_openapi.go
+++ b/internal/apigw/apigw_openapi.go
@@ -23,7 +23,7 @@ type route struct {
 
 func (module *Module) buildOpenAPI(ctx pgsgo.Context, in pgs.Service) (*dm_v3.Document, error) {
 	doc := &dm_v3.Document{
-		Version: "3.1.0",
+		Version: "3.0.0",
 		// NOTE: Info is required to be a valid OAS,
 		// but we expect multiple services to Merge()
 		// their OAS together, so we leave it minimally filled out.

--- a/internal/apigw/apigw_openapi.go
+++ b/internal/apigw/apigw_openapi.go
@@ -23,7 +23,7 @@ type route struct {
 
 func (module *Module) buildOpenAPI(ctx pgsgo.Context, in pgs.Service) (*dm_v3.Document, error) {
 	doc := &dm_v3.Document{
-		Version: "3.0.0",
+		Version: "3.0.3",
 		// NOTE: Info is required to be a valid OAS,
 		// but we expect multiple services to Merge()
 		// their OAS together, so we leave it minimally filled out.

--- a/routers/ginapi/ginapi_handler.go
+++ b/routers/ginapi/ginapi_handler.go
@@ -23,7 +23,6 @@ import (
 
 // TODO(pquerna): consider a server option to control this.
 var jsonMarshaler = protojson.MarshalOptions{
-	UseProtoNames:   true,
 	EmitUnpopulated: true,
 }
 


### PR DESCRIPTION
On the Cone side, the code generator does not create valid objects from the API spec. We believe it's because the openapi generator is actually creating a `v3.0.0` spec and not a `v3.1.0` spec. Setting this value to `3.0.0` generates no differences in the output yaml (outside of the version), and allows our downstream generator to work properly. This also removes the marshal option that sets proto names, as we need the `camelCase` data on the receiving field