### PR TITLE
Anthony/rpc nested field support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /build
 /.idea
+/.vscode

--- a/example/bookstore/v1/bookstore.pb.apigw.go
+++ b/example/bookstore/v1/bookstore.pb.apigw.go
@@ -18,6 +18,7 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/encoding/protowire"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/testing/protopack"
 )
 
@@ -506,6 +507,67 @@ func _BookstoreService_UpdateBook_APIGW_Decoder(ctx context.Context, input apigw
 	}
 
 	err = unmarshalOpts.Unmarshal(vn1.Marshal(), out)
+	if err != nil {
+		return err
+	}
+
+	reflection := out.ProtoReflect()
+	var (
+		field         protoreflect.FieldDescriptor
+		value         protoreflect.Value
+		isTraversable bool
+	)
+
+	isTraversable = false
+	reflection.Range(func(fd protoreflect.FieldDescriptor, v protoreflect.Value) bool {
+		if fd.Number() == 2 {
+			field = fd
+			value = v
+			isTraversable = true
+			return false
+		}
+		return true
+	})
+	if !isTraversable {
+		return status.Error(codes.InvalidArgument, "Unable to find nested field")
+	}
+	reflection = field.Message().Options().ProtoReflect()
+
+	isTraversable = false
+	reflection.Range(func(fd protoreflect.FieldDescriptor, v protoreflect.Value) bool {
+		if fd.Number() == 1 {
+			field = fd
+			value = v
+			isTraversable = true
+			return false
+		}
+		return true
+	})
+	if !isTraversable {
+		return status.Error(codes.InvalidArgument, "Unable to find nested field")
+	}
+	reflection = field.Message().Options().ProtoReflect()
+
+	vn3tmp, err := strconv.ParseInt(value.String(), 10, 64)
+	if err != nil {
+		return status.Errorf(codes.InvalidArgument, "id is not a valid int: %s", err)
+	}
+
+	var (
+		arr [1]protopack.Message
+		vn3 protopack.Message
+	)
+	arr[0] = protopack.Message{
+		protopack.Tag{Number: 1, Type: protopack.VarintType},
+		protopack.Varint(vn3tmp),
+	}
+
+	vn3 = protopack.Message{
+		protopack.Tag{Number: 2, Type: protopack.BytesType},
+		arr[0],
+	}
+
+	err = unmarshalOpts.Unmarshal(vn3.Marshal(), out)
 	if err != nil {
 		return err
 	}

--- a/example/bookstore/v1/bookstore.pb.apigw.go
+++ b/example/bookstore/v1/bookstore.pb.apigw.go
@@ -511,7 +511,6 @@ func _BookstoreService_UpdateBook_APIGW_Decoder(ctx context.Context, input apigw
 		return err
 	}
 
-<<<<<<< HEAD
 	reflection := out.ProtoReflect()
 	var (
 		field         protoreflect.FieldDescriptor
@@ -519,12 +518,6 @@ func _BookstoreService_UpdateBook_APIGW_Decoder(ctx context.Context, input apigw
 		isTraversable bool
 	)
 
-=======
-	var field protoreflect.FieldDescriptor
-	var value protoreflect.Value
-	var isTraversable bool
-	reflection := out.ProtoReflect()
->>>>>>> origin/anthony/nested-field-support
 	isTraversable = false
 	reflection.Range(func(fd protoreflect.FieldDescriptor, v protoreflect.Value) bool {
 		if fd.Number() == 2 {
@@ -560,27 +553,20 @@ func _BookstoreService_UpdateBook_APIGW_Decoder(ctx context.Context, input apigw
 		return status.Errorf(codes.InvalidArgument, "id is not a valid int: %s", err)
 	}
 
-<<<<<<< HEAD
 	var (
 		arr [1]protopack.Message
 		vn3 protopack.Message
 	)
 	arr[0] = protopack.Message{
-=======
-	vn3 := protopack.Message{
->>>>>>> origin/anthony/nested-field-support
 		protopack.Tag{Number: 1, Type: protopack.VarintType},
 		protopack.Varint(vn3tmp),
 	}
 
-<<<<<<< HEAD
 	vn3 = protopack.Message{
 		protopack.Tag{Number: 2, Type: protopack.BytesType},
 		arr[0],
 	}
 
-=======
->>>>>>> origin/anthony/nested-field-support
 	err = unmarshalOpts.Unmarshal(vn3.Marshal(), out)
 	if err != nil {
 		return err

--- a/go.work.sum
+++ b/go.work.sum
@@ -199,6 +199,7 @@ github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/googleapis/enterprise-certificate-proxy v0.2.3/go.mod h1:AwSRAtLfXpU5Nm3pW+v7rGDHp09LsPtGY9MduiEsR9k=
 github.com/googleapis/gax-go/v2 v2.7.1/go.mod h1:4orTrqY6hXxxaUL4LHIPl6lGo8vAE38/qKbhSAKP6QI=
 go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=
+go.uber.org/goleak v1.1.11/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
 golang.org/x/crypto v0.7.0/go.mod h1:pYwdfH91IfpZVANVyUOhSIPZaFoJGxTFbZhFTx+dXZU=
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=

--- a/internal/apigw/apigw_imports.go
+++ b/internal/apigw/apigw_imports.go
@@ -25,6 +25,7 @@ type importTracker struct {
 	Ogen                      bool
 	ProtobufEncodingJSON      bool
 	ProtobufProto             bool
+	ProtobufReflect           bool
 	ProtobufProtoPack         bool
 	ProtobufEncodingProtowire bool
 	Strconv                   bool

--- a/internal/apigw/apigw_method.go
+++ b/internal/apigw/apigw_method.go
@@ -402,6 +402,7 @@ func (module *Module) generateNestedFieldConverter(method pgs.Method, edgeNumber
 	inputName string,
 	outputName string,
 ) (*paramContext, error) {
+	ix.ProtobufReflect = true
 	const varName = "reflection"
 	converterSubstringRef, err := module.generateNestedFieldConverterStr(method, ix, outputName, edgeNumbers, method.Input(), varName)
 	converterSubstring := *converterSubstringRef

--- a/internal/apigw/apigw_method.go
+++ b/internal/apigw/apigw_method.go
@@ -324,10 +324,7 @@ func (module *Module) generateFieldConverter(method pgs.Method, edgeNumber proto
 		return nil, fmt.Errorf("apigw: methodContext: operation.Route invalid: target field is unknown '%s'", method.FullyQualifiedName())
 	}
 }
-func (module *Module) generateNestedFieldConverterStr(method pgs.Method, ix *importTracker, outputName string, edgeNumbers []protopack.Number, msg pgs.Message, varName string) (*string, error) {
-	converter := ""
 
-<<<<<<< HEAD
 func (module *Module) generateNestedProtoMessageOutput(idx int, edgeNumbers []protopack.Number, outputName string) string {
 	var inputName string
 
@@ -358,8 +355,6 @@ func (module *Module) generateNestedProtoMessageOutput(idx int, edgeNumbers []pr
 func (module *Module) generateNestedFieldConverterStr(method pgs.Method, ix *importTracker, outputName string, edgeNumbers []protopack.Number, msg pgs.Message, varName string) (*string, error) {
 	converter := ""
 
-=======
->>>>>>> origin/anthony/nested-field-support
 	var lastField pgs.Field
 	next := edgeNumbers[0]
 	deeper := edgeNumbers[1:]
@@ -409,7 +404,6 @@ func (module *Module) generateNestedFieldConverter(method pgs.Method, edgeNumber
 	outputName string,
 ) (*paramContext, error) {
 	const varName = "reflection"
-<<<<<<< HEAD
 	converterSubstringRef, err := module.generateNestedFieldConverterStr(method, ix, outputName, edgeNumbers, method.Input(), varName)
 	converterSubstring := *converterSubstringRef
 	if err != nil {
@@ -428,29 +422,19 @@ func (module *Module) generateNestedFieldConverter(method pgs.Method, edgeNumber
 		IntialValue: converterSubstring[idx+len(outputStatement):],
 		OutputName:  outputName,
 	})
-=======
-	converterSubstring, err := module.generateNestedFieldConverterStr(method, ix, outputName, edgeNumbers, method.Input(), varName)
->>>>>>> origin/anthony/nested-field-support
 	if err != nil {
 		panic(err)
 	}
 
-<<<<<<< HEAD
-	// Starts at 1 because the intializer completes the first level
 	protopackMessage := module.generateNestedProtoMessageOutput(0, edgeNumbers, outputName)
 	converterSubstring = converterSubstring[:idx] + ppMessageIntializer + protopackMessage
 	converter := fmt.Sprintf("%s\n%s", intializer, converterSubstring)
-=======
-	intializerStr := fmt.Sprintf("var field protoreflect.FieldDescriptor\nvar value protoreflect.Value\nvar isTraversable bool\n%s:= out.ProtoReflect()", varName)
-	converter := fmt.Sprintf("%s\n%s", intializerStr, *converterSubstring)
->>>>>>> origin/anthony/nested-field-support
 	return &paramContext{
 		ConverterOutputName: outputName,
 		Converter:           converter,
 	}, nil
 }
 
-<<<<<<< HEAD
 type protopackMessageIntializerContext struct {
 	Size        int
 	IntialValue string
@@ -464,8 +448,6 @@ type protopackMessageContext struct {
 type messageFieldIntializerContext struct {
 	VarName string
 }
-=======
->>>>>>> origin/anthony/nested-field-support
 type messageFieldContext struct {
 	Number     protopack.Number
 	OutputName string

--- a/internal/apigw/apigw_method.go
+++ b/internal/apigw/apigw_method.go
@@ -153,7 +153,6 @@ func (module *Module) methodContext(ctx pgsgo.Context, w io.Writer, f pgs.File, 
 		var fc *paramContext
 		if len(nums) == 1 {
 			fc, err = module.generateFieldConverter(method, nums[0], edgeField, ix, routeGetter, paramValueName, outName)
-
 		} else {
 			fc, err = module.generateNestedFieldConverter(method, nums, ix, routeGetter, paramValueName, outName)
 		}

--- a/internal/apigw/apigw_method.go
+++ b/internal/apigw/apigw_method.go
@@ -34,6 +34,8 @@ type paramContext struct {
 	ConverterOutputName string
 }
 
+const outputSuffix = ":= protopack.Message{\n"
+
 func jsonName(f pgs.Field) string {
 	if f.Descriptor().JsonName != nil {
 		return *f.Descriptor().JsonName
@@ -42,7 +44,7 @@ func jsonName(f pgs.Field) string {
 }
 
 func (module *Module) path2fieldNumbers(path []string, msg pgs.Message) ([]protopack.Number, pgs.Field) {
-	var lasField pgs.Field
+	var lastField pgs.Field
 	if len(path) == 0 {
 		return nil, nil
 	}
@@ -51,7 +53,7 @@ func (module *Module) path2fieldNumbers(path []string, msg pgs.Message) ([]proto
 	deeper := path[1:]
 	for _, f := range msg.Fields() {
 		if next == jsonName(f) || next == f.Name().String() {
-			lasField = f
+			lastField = f
 			rv = append(rv, protopack.Number(f.Descriptor().GetNumber()))
 			if len(deeper) >= 1 {
 				nestedMsg := f.Type().Embed()
@@ -59,7 +61,7 @@ func (module *Module) path2fieldNumbers(path []string, msg pgs.Message) ([]proto
 					panic("apigw: getFieldNumbers: unexpected path: " + strings.Join(path, ".") + " on " + msg.FullyQualifiedName())
 				}
 				nums, edgeField := module.path2fieldNumbers(deeper, nestedMsg)
-				lasField = edgeField
+				lastField = edgeField
 				rv = append(rv, nums...)
 			}
 			break
@@ -68,7 +70,7 @@ func (module *Module) path2fieldNumbers(path []string, msg pgs.Message) ([]proto
 	if len(rv) == 0 {
 		panic("apigw: getFieldNumbers: unexpected path: " + strings.Join(path, ".") + " on " + msg.FullyQualifiedName())
 	}
-	return rv, lasField
+	return rv, lastField
 }
 
 func isInt(pt pgs.ProtoType) bool {
@@ -130,17 +132,8 @@ func (module *Module) methodContext(ctx pgsgo.Context, w io.Writer, f pgs.File, 
 			continue
 		}
 
-		nesteFields := strings.Split(part.ParamName, ".")
-		// TODO(pquerna): support nested fields
-		if len(nesteFields) != 1 {
-			module.Logf("apigw: methodContext: operation.Route invalid: target field is nested (unsupported right now) '%s' for route '%s'", method.FullyQualifiedName(), operation.Route)
-			continue
-		}
-
-		nums, edgeField := module.path2fieldNumbers(nesteFields, method.Input())
-		if len(nums) != 1 {
-			return nil, fmt.Errorf("apigw: methodContext: operation.Route invalid: target numbers is nested (unsupported right now) '%s': %w", method.FullyQualifiedName(), err)
-		}
+		nestedFields := strings.Split(part.ParamName, ".")
+		nums, edgeField := module.path2fieldNumbers(nestedFields, method.Input())
 
 		paramValueName := vn.String()
 		vn = vn.Next()
@@ -157,7 +150,13 @@ func (module *Module) methodContext(ctx pgsgo.Context, w io.Writer, f pgs.File, 
 		outName := vn.String()
 		vn = vn.Next()
 
-		fc, err := module.generateFieldConverter(method, nums[0], edgeField, ix, routeGetter, paramValueName, outName)
+		var fc *paramContext
+		if len(nums) == 1 {
+			fc, err = module.generateFieldConverter(method, nums[0], edgeField, ix, routeGetter, paramValueName, outName)
+
+		} else {
+			fc, err = module.generateNestedFieldConverter(method, nums, ix, routeGetter, paramValueName, outName)
+		}
 		if err != nil {
 			panic(err)
 		}
@@ -326,6 +325,135 @@ func (module *Module) generateFieldConverter(method pgs.Method, edgeNumber proto
 	}
 }
 
+func (module *Module) generateNestedProtoMessageOutput(idx int, edgeNumbers []protopack.Number, outputName string) string {
+	var inputName string
+
+	// The first edge number is the last step and writes to the output instead of an array
+	if idx == 0 {
+		inputName = outputName
+	} else {
+		inputName = fmt.Sprintf("arr[%d]", idx+1)
+	}
+
+	message, err := templateExecToString("protopack_message.tmpl", &protopackMessageContext{
+		InputName: inputName,
+		Number:    edgeNumbers[idx],
+		// We need to -2 because the last level is the initializer and the second to last level is the base case
+		Index: len(edgeNumbers) - idx - 2,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	// Base case
+	if idx == len(edgeNumbers)-2 {
+		return message
+	}
+	return fmt.Sprintf("%s\n%s", module.generateNestedProtoMessageOutput(idx+1, edgeNumbers, outputName), message)
+}
+
+func (module *Module) generateNestedFieldConverterStr(method pgs.Method, ix *importTracker, outputName string, edgeNumbers []protopack.Number, msg pgs.Message, varName string) (*string, error) {
+	converter := ""
+
+	var lastField pgs.Field
+	next := edgeNumbers[0]
+	deeper := edgeNumbers[1:]
+
+	// Generate the converter part for this level
+	converterPart, err := templateExecToString("field_message.tmpl", &messageFieldContext{
+		Number:     next,
+		InputName:  varName,
+		OutputName: varName,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	// Find the next message
+	for _, f := range msg.Fields() {
+		if next == protopack.Number(f.Descriptor().GetNumber()) {
+			lastField = f
+			break
+		}
+	}
+	var converterSubstring *string
+	if len(edgeNumbers) == 1 {
+		// Base case
+		paramContext, err := module.generateFieldConverter(method, next, lastField, ix, "", "value.String()", outputName)
+		if err != nil {
+			panic(err)
+		}
+		converterSubstring = &paramContext.Converter
+	} else {
+		// Recurse
+		converterSubstring, err = module.generateNestedFieldConverterStr(method, ix, outputName, deeper, lastField.Type().Embed(), varName)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	// Combine the converter substring from this level and the previous levels
+	converter = fmt.Sprintf("%s\n%s", converterPart, *converterSubstring)
+	return &converter, nil
+}
+
+func (module *Module) generateNestedFieldConverter(method pgs.Method, edgeNumbers []protopack.Number,
+	ix *importTracker,
+	valueGetter string,
+	inputName string,
+	outputName string,
+) (*paramContext, error) {
+	const varName = "reflection"
+	converterSubstringRef, err := module.generateNestedFieldConverterStr(method, ix, outputName, edgeNumbers, method.Input(), varName)
+	converterSubstring := *converterSubstringRef
+	if err != nil {
+		panic(err)
+	}
+	intializer, err := templateExecToString("field_message_intializer.tmpl", &messageFieldIntializerContext{
+		VarName: varName,
+	})
+	if err != nil {
+		panic(err)
+	}
+	outputStatement := fmt.Sprintf("%s %s", outputName, outputSuffix)
+	idx := strings.Index(converterSubstring, outputStatement)
+	ppMessageIntializer, err := templateExecToString("protopack_message_intializer.tmpl", &protopackMessageIntializerContext{
+		Size:        len(edgeNumbers) - 1,
+		IntialValue: converterSubstring[idx+len(outputStatement):],
+		OutputName:  outputName,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	// Starts at 1 because the intializer completes the first level
+	protopackMessage := module.generateNestedProtoMessageOutput(0, edgeNumbers, outputName)
+	converterSubstring = converterSubstring[:idx] + ppMessageIntializer + protopackMessage
+	converter := fmt.Sprintf("%s\n%s", intializer, converterSubstring)
+	return &paramContext{
+		ConverterOutputName: outputName,
+		Converter:           converter,
+	}, nil
+}
+
+type protopackMessageIntializerContext struct {
+	Size        int
+	IntialValue string
+	OutputName  string
+}
+type protopackMessageContext struct {
+	InputName string
+	Number    protopack.Number
+	Index     int
+}
+type messageFieldIntializerContext struct {
+	VarName string
+}
+type messageFieldContext struct {
+	Number     protopack.Number
+	OutputName string
+	InputName  string
+}
 type boolFieldContext struct {
 	FieldName  string
 	Getter     string

--- a/internal/apigw/templates/field_message.tmpl
+++ b/internal/apigw/templates/field_message.tmpl
@@ -1,0 +1,14 @@
+isTraversable = false
+{{.InputName}}.Range(func(fd protoreflect.FieldDescriptor, v protoreflect.Value) bool {
+    if fd.Number() == {{.Number}} {
+        field = fd
+        value = v
+        isTraversable = true
+        return false
+    }
+    return true
+})
+if !isTraversable {
+    return status.Error(codes.InvalidArgument, "Unable to find nested field")
+}
+{{.OutputName}} = field.Message().Options().ProtoReflect()

--- a/internal/apigw/templates/field_message_intializer.tmpl
+++ b/internal/apigw/templates/field_message_intializer.tmpl
@@ -1,0 +1,6 @@
+{{.VarName}} := out.ProtoReflect()
+var (
+    field protoreflect.FieldDescriptor;
+    value protoreflect.Value;
+    isTraversable bool;
+)

--- a/internal/apigw/templates/header.tmpl
+++ b/internal/apigw/templates/header.tmpl
@@ -22,6 +22,7 @@ import (
 {{ if .Imports.GRPCStatus }} "google.golang.org/grpc/status" {{ end }}
 {{ if .Imports.ProtobufProto }} "google.golang.org/protobuf/proto" {{ end }}
 {{ if .Imports.ProtobufProtoPack }} "google.golang.org/protobuf/testing/protopack" {{ end }}
+{{ if .Imports.ProtobufReflect }} "google.golang.org/protobuf/reflect/protoreflect" {{ end }}
 {{ if .Imports.ProtobufEncodingJSON }} "google.golang.org/protobuf/encoding/protojson" {{ end }}
 {{ if .Imports.ProtobufEncodingProtowire }} "google.golang.org/protobuf/encoding/protowire" {{ end }}
 

--- a/internal/apigw/templates/protopack_message.tmpl
+++ b/internal/apigw/templates/protopack_message.tmpl
@@ -1,0 +1,4 @@
+{{.InputName}} = protopack.Message{
+    protopack.Tag{Number: {{- .Number -}}, Type: protopack.BytesType},
+    arr[{{.Index}}],
+}

--- a/internal/apigw/templates/protopack_message_intializer.tmpl
+++ b/internal/apigw/templates/protopack_message_intializer.tmpl
@@ -1,0 +1,6 @@
+var (
+    arr [{{.Size}}]protopack.Message;
+    {{.OutputName}} protopack.Message;
+)
+arr[0] = protopack.Message{
+{{.IntialValue}}


### PR DESCRIPTION
Added two recursive functions 

generateNestedProtoMessageOutput generates the nested protopack.Message. To avoid large nesting instead of doing

```
protopack.Message{ 
  protopack.Tag{...
  protopack.Message{ ...
     protopack.Tag{...
     protopack.Message{ 
```
     
I used an array as an intermediary 

generateNestedFieldConverterStr generated the converters for each level. This is necessary in order to obtain the innermost field.


Looks like it works!

<img width="2542" alt="image" src="https://github.com/ductone/protoc-gen-apigw/assets/60042005/da7f72d1-59dd-4aa9-8c58-68168fee0ff9">
