### PR TITLE
Properly nests the protobuf oneof fields in the openapi spec

### DIFF
--- a/example/bookstore/v1/bookstore.pb.bookstore_service.oas31.yaml
+++ b/example/bookstore/v1/bookstore.pb.bookstore_service.oas31.yaml
@@ -112,20 +112,22 @@ components:
       properties:
         author:
           $ref: '#/components/schemas/bookstore.v1.Author'
-        fiction:
-          description: |-
-            The fiction field.
-            This field is part of the `genre` oneof.
-            See the documentation for `bookstore.v1.GetAuthorResponse` for more details.
-          nullable: true
-          type: boolean
-        nonfiction:
-          description: |-
-            The nonfiction field.
-            This field is part of the `genre` oneof.
-            See the documentation for `bookstore.v1.GetAuthorResponse` for more details.
-          nullable: true
-          type: boolean
+        genre:
+          properties:
+            fiction:
+              description: |-
+                The fiction field.
+                This field is part of the `genre` oneof.
+                See the documentation for `bookstore.v1.GetAuthorResponse` for more details.
+              nullable: true
+              type: boolean
+            nonfiction:
+              description: |-
+                The nonfiction field.
+                This field is part of the `genre` oneof.
+                See the documentation for `bookstore.v1.GetAuthorResponse` for more details.
+              nullable: true
+              type: boolean
       type: object
       x-speakeasy-name-override: GetAuthorResponse
     bookstore.v1.GetBookResponse:

--- a/internal/apigw/apigw_openapi_schema.go
+++ b/internal/apigw/apigw_openapi_schema.go
@@ -119,12 +119,16 @@ func (sc *schemaContainer) Message(m pgs.Message, filter []string, nullable *boo
 			of.Name().String(),
 		)
 
+		jn := of.Name().String()
+		sch := &dm_base.Schema{
+			Properties: map[string]*dm_base.SchemaProxy{},
+		}
 		for _, f := range of.Fields() {
 			jn := jsonName(f)
-			obj.Properties[jn] = sc.Field(f)
-
+			sch.Properties[jn] = sc.Field(f)
 			_, _ = fmt.Fprintf(description, "  - %s\n", jn)
 		}
+		obj.Properties[jn] = dm_base.CreateSchemaProxy(sch)
 	}
 	obj.Description = description.String()
 	rv := dm_base.CreateSchemaProxy(obj)
@@ -179,7 +183,6 @@ func (sc *schemaContainer) Field(f pgs.Field) *dm_base.SchemaProxy {
 		description += "\nThis field is part of the `" + f.OneOf().Name().String() + "` oneof.\n" +
 			"See the documentation for `" + nicerFQN(f.Message()) + "` for more details."
 	}
-
 	switch {
 	case f.Type().IsRepeated():
 		fteSchema := sc.FieldTypeElem(f.Type().Element())


### PR DESCRIPTION
Nests the protobuf oneof fields in the open api spec.
This:
```
properties:
        author:
          $ref: '#/components/schemas/bookstore.v1.Author'
        fiction:
          description: |-
            The fiction field.
            This field is part of the `genre` oneof.
            See the documentation for `bookstore.v1.GetAuthorResponse` for more details.
          nullable: true
          type: boolean
        nonfiction:
          description: |-
            The nonfiction field.
            This field is part of the `genre` oneof.
            See the documentation for `bookstore.v1.GetAuthorResponse` for more details.
          nullable: true
          type: boolean
```
Goes to this:
```
properties:
        author:
          $ref: '#/components/schemas/bookstore.v1.Author'
        genre:
          properties:
            fiction:
              description: |-
                The fiction field.
                This field is part of the `genre` oneof.
                See the documentation for `bookstore.v1.GetAuthorResponse` for more details.
              nullable: true
              type: boolean
            nonfiction:
              description: |-
                The nonfiction field.
                This field is part of the `genre` oneof.
                See the documentation for `bookstore.v1.GetAuthorResponse` for more details.
              nullable: true
              type: boolean
```