### PR TITLE
Updated ints to be integers

### DIFF
--- a/example/bookstore/v1/bookstore.pb.bookstore_service.oas31.yaml
+++ b/example/bookstore/v1/bookstore.pb.bookstore_service.oas31.yaml
@@ -400,7 +400,7 @@ paths:
           schema:
             description: The pageSize field.
             format: int32
-            type: number
+            type: integer
         - in: query
           name: page_token
           schema:

--- a/internal/apigw/apigw_openapi.go
+++ b/internal/apigw/apigw_openapi.go
@@ -24,6 +24,8 @@ type route struct {
 	Method string
 }
 
+const SchemaProxyRefPrefix = "#/components/schemas/"
+
 func (module *Module) buildOpenAPI(ctx pgsgo.Context, in pgs.Service) (*dm_v3.Document, error) {
 	doc := &dm_v3.Document{
 		Version: "3.1.0",
@@ -365,7 +367,7 @@ func (mt *msgTracker) AddInput(m pgs.Message, filter []string) *dm_base.SchemaPr
 		mt.messages[fqn] = &schemaData{path: fqn, msg: m, filter: filter}
 	}
 
-	return dm_base.CreateSchemaProxyRef("#/components/schemas/" + fqn)
+	return dm_base.CreateSchemaProxyRef(SchemaProxyRefPrefix + fqn)
 }
 
 func (mt *msgTracker) Add(m pgs.Message) *dm_base.SchemaProxy {
@@ -374,7 +376,7 @@ func (mt *msgTracker) Add(m pgs.Message) *dm_base.SchemaProxy {
 	}
 	fqn := nicerFQN(m)
 	mt.messages[fqn] = &schemaData{path: fqn, msg: m}
-	return dm_base.CreateSchemaProxyRef("#/components/schemas/" + fqn)
+	return dm_base.CreateSchemaProxyRef(SchemaProxyRefPrefix + fqn)
 }
 
 func contains[T comparable](needle T, haystack []T) bool {

--- a/internal/apigw/apigw_openapi_scalar.go
+++ b/internal/apigw/apigw_openapi_scalar.go
@@ -19,7 +19,7 @@ func (sc *schemaContainer) schemaForScalar(pt pgs.ProtoType) *dm_base.Schema {
 		}
 	case pgs.Int32T, pgs.SFixed32, pgs.SInt32:
 		return &dm_base.Schema{
-			Type:   []string{"number"},
+			Type:   []string{"integer"},
 			Format: "int32",
 		}
 	case pgs.UInt64T, pgs.Fixed64T:
@@ -29,7 +29,7 @@ func (sc *schemaContainer) schemaForScalar(pt pgs.ProtoType) *dm_base.Schema {
 		}
 	case pgs.UInt32T, pgs.Fixed32T:
 		return &dm_base.Schema{
-			Type:   []string{"number"},
+			Type:   []string{"integer"},
 			Format: "uint32",
 		}
 	case pgs.StringT:

--- a/internal/apigw/apigw_openapi_schema.go
+++ b/internal/apigw/apigw_openapi_schema.go
@@ -95,7 +95,7 @@ func (sc *schemaContainer) Message(m pgs.Message, filter []string, nullable *boo
 	}
 
 	if sc.schemas[fqn] != nil {
-		return dm_base.CreateSchemaProxyRef("#/components/schemas/" + fqn)
+		return dm_base.CreateSchemaProxyRef(SchemaProxyRefPrefix + fqn)
 	}
 
 	description := &strings.Builder{}
@@ -158,7 +158,7 @@ func (sc *schemaContainer) Message(m pgs.Message, filter []string, nullable *boo
 	obj.Description = description.String()
 	rv := dm_base.CreateSchemaProxy(obj)
 	sc.schemas[fqn] = rv
-	return dm_base.CreateSchemaProxyRef("#/components/schemas/" + fqn)
+	return dm_base.CreateSchemaProxyRef(SchemaProxyRefPrefix + fqn)
 }
 
 func (sc *schemaContainer) OneOf(of pgs.OneOf) []*dm_base.SchemaProxy {

--- a/internal/apigw/apigw_openapi_wkt.go
+++ b/internal/apigw/apigw_openapi_wkt.go
@@ -80,13 +80,13 @@ func (sc *schemaContainer) schemaForWKT(wkt pgs.WellKnownType) *dm_base.Schema {
 		}
 	case pgs.Int32ValueWKT:
 		return &dm_base.Schema{
-			Type:     []string{"number"},
+			Type:     []string{"integer"},
 			Format:   "int32",
 			Nullable: oasTrue(),
 		}
 	case pgs.UInt32ValueWKT:
 		return &dm_base.Schema{
-			Type:     []string{"number"},
+			Type:     []string{"integer"},
 			Format:   "int64",
 			Nullable: oasTrue(),
 		}


### PR DESCRIPTION
The integers are using numbers which the go sdk generation interprets as floats, it should be a integer instead so it will correctly be autogenerated.