### PR TITLE
Add nullable based on required_spec field option

### DIFF
--- a/example/bookstore/v1/bookstore.pb.bookstore_service.oas31.yaml
+++ b/example/bookstore/v1/bookstore.pb.bookstore_service.oas31.yaml
@@ -21,11 +21,14 @@ components:
           type: array
           x-sunset: "2025-08-15"
         createdAt:
-          format: date-time
-          readOnly: true
-          type: string
+          oneOf:
+            - format: date-time
+              readOnly: true
+              type: string
+            - type: "null"
         firstName:
           description: The firstName field.
+          nullable: true
           readOnly: false
           type: string
         gender:
@@ -34,6 +37,7 @@ components:
             - GENDER_UNSPECIFIED
             - GENDER_MALE
             - GENDER_FEMALE
+          nullable: true
           readOnly: false
           type: string
           x-speakeasy-unknown-values: allow
@@ -52,14 +56,17 @@ components:
         id:
           description: A unique author id.
           format: int64
+          nullable: true
           readOnly: false
           type: string
         lname:
           description: The lname field.
+          nullable: true
           readOnly: false
           type: string
         metadata:
           description: The metadata field.
+          nullable: true
           readOnly: true
           type: string
           x-stability-level: beta
@@ -71,6 +78,7 @@ components:
       properties:
         author:
           description: An author of the book.
+          nullable: true
           readOnly: false
           type: string
           x-stability-level: stable
@@ -90,11 +98,13 @@ components:
         shelfId:
           deprecated: true
           description: Shelf ID - deprecated, use shelf reference instead
+          nullable: true
           readOnly: false
           type: string
           x-sunset: "2025-09-30"
         title:
           description: A book title.
+          nullable: true
           readOnly: false
           type: string
           x-stability-level: stable
@@ -108,7 +118,9 @@ components:
       description: Request message for CreateBook method.
       properties:
         book:
-          $ref: '#/components/schemas/bookstore.v1.Book'
+          oneOf:
+            - $ref: '#/components/schemas/bookstore.v1.Book'
+            - type: "null"
       title: Create Book Request
       type: object
       x-speakeasy-name-override: CreateBookRequest
@@ -116,7 +128,9 @@ components:
       description: The CreateBookResponse message.
       properties:
         book:
-          $ref: '#/components/schemas/bookstore.v1.Book'
+          oneOf:
+            - $ref: '#/components/schemas/bookstore.v1.Book'
+            - type: "null"
       title: Create Book Response
       type: object
       x-speakeasy-name-override: CreateBookResponse
@@ -125,6 +139,7 @@ components:
       properties:
         name:
           description: The name field.
+          nullable: true
           readOnly: false
           type: string
       title: Create Genre Request
@@ -134,7 +149,9 @@ components:
       description: The CreateGenreResponse message.
       properties:
         genre:
-          $ref: '#/components/schemas/bookstore.v1.Genre'
+          oneOf:
+            - $ref: '#/components/schemas/bookstore.v1.Genre'
+            - type: "null"
       title: Create Genre Response
       type: object
       x-speakeasy-name-override: CreateGenreResponse
@@ -142,7 +159,9 @@ components:
       description: Request message for CreateShelf method.
       properties:
         shelf:
-          $ref: '#/components/schemas/bookstore.v1.Shelf'
+          oneOf:
+            - $ref: '#/components/schemas/bookstore.v1.Shelf'
+            - type: "null"
       title: Create Shelf Request
       type: object
       x-speakeasy-name-override: CreateShelfRequest
@@ -150,7 +169,9 @@ components:
       description: The CreateShelfResponse message.
       properties:
         shelf:
-          $ref: '#/components/schemas/bookstore.v1.Shelf'
+          oneOf:
+            - $ref: '#/components/schemas/bookstore.v1.Shelf'
+            - type: "null"
       title: Create Shelf Response
       type: object
       x-speakeasy-name-override: CreateShelfResponse
@@ -158,7 +179,9 @@ components:
       description: Request message for DeleteBook method.
       properties:
         book:
-          $ref: '#/components/schemas/bookstore.v1.Book'
+          oneOf:
+            - $ref: '#/components/schemas/bookstore.v1.Book'
+            - type: "null"
       title: Delete Book Request
       type: object
       x-speakeasy-name-override: DeleteBookRequest
@@ -193,11 +216,13 @@ components:
         id:
           description: A unique genre id.
           format: int64
+          nullable: true
           readOnly: false
           type: string
           x-stability-level: alpha
         name:
           description: A genre name.
+          nullable: true
           readOnly: false
           type: string
           x-stability-level: alpha
@@ -215,7 +240,9 @@ components:
           - nonfiction
       properties:
         author:
-          $ref: '#/components/schemas/bookstore.v1.Author'
+          oneOf:
+            - $ref: '#/components/schemas/bookstore.v1.Author'
+            - type: "null"
         fiction:
           description: |-
             The fiction field.
@@ -239,7 +266,9 @@ components:
       description: The GetBookResponse message.
       properties:
         book:
-          $ref: '#/components/schemas/bookstore.v1.Book'
+          oneOf:
+            - $ref: '#/components/schemas/bookstore.v1.Book'
+            - type: "null"
       title: Get Book Response
       type: object
       x-speakeasy-name-override: GetBookResponse
@@ -247,7 +276,9 @@ components:
       description: The GetGenreResponse message.
       properties:
         genre:
-          $ref: '#/components/schemas/bookstore.v1.Genre'
+          oneOf:
+            - $ref: '#/components/schemas/bookstore.v1.Genre'
+            - type: "null"
       title: Get Genre Response
       type: object
       x-speakeasy-name-override: GetGenreResponse
@@ -281,9 +312,10 @@ components:
       description: Response to ListShelves call.
       properties:
         mask:
-          nullable: true
-          readOnly: false
-          type: string
+          oneOf:
+            - readOnly: false
+              type: string
+            - type: "null"
         shelves:
           description: Shelves in the bookstore.
           items:
@@ -299,10 +331,13 @@ components:
       properties:
         anotherProp:
           description: This is a non recursive secondary prop
+          nullable: true
           readOnly: false
           type: string
         page:
-          $ref: '#/components/schemas/bookstore.v1.RecursivePage'
+          oneOf:
+            - $ref: '#/components/schemas/bookstore.v1.RecursivePage'
+            - type: "null"
       title: Recursive Book Response
       type: object
       x-speakeasy-name-override: RecursiveBookResponse
@@ -310,7 +345,9 @@ components:
       description: A recursive page for the recursive response
       properties:
         books:
-          $ref: '#/components/schemas/bookstore.v1.RecursiveBookResponse'
+          oneOf:
+            - $ref: '#/components/schemas/bookstore.v1.RecursiveBookResponse'
+            - type: "null"
         extraPages:
           description: This is a list of recursive pages
           items:
@@ -327,6 +364,7 @@ components:
           type: array
         prop:
           description: This is a non recursive prop
+          nullable: true
           readOnly: false
           type: string
       title: Recursive Page
@@ -337,19 +375,23 @@ components:
       properties:
         id:
           description: A unique shelf id.
+          nullable: true
           readOnly: false
           type: string
           x-stability-level: stable
         search%5Bencoded%5D:
           description: To test json name is percentage encoded
+          nullable: true
           readOnly: false
           type: string
         search[decoded]:
           description: To test json name is percentage decoded
+          nullable: true
           readOnly: false
           type: string
         theme:
           description: A theme of the shelf (fiction, poetry, etc).
+          nullable: true
           readOnly: false
           type: string
           x-stability-level: stable
@@ -360,9 +402,12 @@ components:
       description: Request message for UpdateBook method
       properties:
         book:
-          $ref: '#/components/schemas/bookstore.v1.Book'
+          oneOf:
+            - $ref: '#/components/schemas/bookstore.v1.Book'
+            - type: "null"
         shelf:
           description: The ID of the shelf from which to retrieve a book.
+          nullable: true
           readOnly: false
           type: string
       title: Update Book Request
@@ -372,7 +417,9 @@ components:
       description: The UpdateBookResponse message.
       properties:
         book:
-          $ref: '#/components/schemas/bookstore.v1.Book'
+          oneOf:
+            - $ref: '#/components/schemas/bookstore.v1.Book'
+            - type: "null"
       title: Update Book Response
       type: object
       x-speakeasy-name-override: UpdateBookResponse
@@ -395,6 +442,7 @@ paths:
           schema:
             description: The ID of the author resource to retrieve.
             format: int64
+            nullable: true
             readOnly: false
             type: string
       responses:
@@ -441,6 +489,7 @@ paths:
           required: true
           schema:
             description: The genreId field.
+            nullable: true
             readOnly: false
             type: string
       requestBody:
@@ -469,6 +518,7 @@ paths:
           required: true
           schema:
             description: The genreId field.
+            nullable: true
             readOnly: false
             type: string
       responses:
@@ -568,6 +618,7 @@ paths:
           required: true
           schema:
             description: The ID of the shelf to delete.
+            nullable: true
             readOnly: false
             type: string
       requestBody:
@@ -599,6 +650,7 @@ paths:
           required: true
           schema:
             description: ID of the shelf which books to list.
+            nullable: true
             readOnly: false
             type: string
       responses:
@@ -635,6 +687,7 @@ paths:
           required: true
           schema:
             description: The ID of the shelf on which to create a book.
+            nullable: true
             readOnly: false
             type: string
       requestBody:
@@ -667,6 +720,7 @@ paths:
           schema:
             deprecated: true
             description: Shelf ID - deprecated, use shelf reference instead
+            nullable: true
             readOnly: false
             type: string
             x-sunset: "2025-09-30"
@@ -706,6 +760,7 @@ paths:
           required: true
           schema:
             description: The ID of the shelf from which to retrieve a book.
+            nullable: true
             readOnly: false
             type: string
         - in: path
@@ -714,12 +769,14 @@ paths:
           schema:
             description: The ID of the book to retrieve.
             format: int64
+            nullable: true
             readOnly: false
             type: string
         - in: query
           name: author
           schema:
             description: The includeAuthor field.
+            nullable: true
             readOnly: false
             type: boolean
         - in: query
@@ -727,12 +784,14 @@ paths:
           schema:
             description: The pageSize field.
             format: int32
+            nullable: true
             readOnly: false
             type: integer
         - in: query
           name: page_token
           schema:
             description: The pageToken field.
+            nullable: true
             readOnly: false
             type: string
       responses:
@@ -760,6 +819,7 @@ paths:
           schema:
             deprecated: true
             description: Shelf ID - deprecated, use shelf reference instead
+            nullable: true
             readOnly: false
             type: string
             x-sunset: "2025-09-30"

--- a/example/webhooks/v1/request.pb.webhooks_v1.oas31.yaml
+++ b/example/webhooks/v1/request.pb.webhooks_v1.oas31.yaml
@@ -12,6 +12,7 @@ components:
              If your receiver returns any other status code, it is expected to not use the callback url.
 
              This value will match the "Webhook-Callback-Url" header.
+          nullable: true
           readOnly: false
           type: string
         event:
@@ -25,22 +26,26 @@ components:
              - "webhooks.v1.PayloadPolicyApprovalStep"
              - "webhooks.v1.PayloadPolicyPostAction"
              - "webhooks.v1.PayloadProvisionStep"
+          nullable: true
           readOnly: false
           type: string
         payload:
-          additionalProperties: true
-          description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
-          properties:
-            '@type':
-              description: The type of the serialized message.
-              type: string
-          readOnly: false
-          type: object
+          oneOf:
+            - additionalProperties: true
+              description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
+              properties:
+                '@type':
+                  description: The type of the serialized message.
+                  type: string
+              readOnly: false
+              type: object
+            - type: "null"
         version:
           description: |-
             version contains the constant value "v1". Future versions of the Webhook body will use a different string.
 
              This value will match the "Webhook-Version" header.
+          nullable: true
           readOnly: false
           type: string
         webhookId:
@@ -48,6 +53,7 @@ components:
             Unique ID for this Webhook. Your receiver should only process this ID once.
 
              This value will match the "Webhook-Id" header.
+          nullable: true
           readOnly: false
           type: string
       title: Body
@@ -72,7 +78,9 @@ components:
           readOnly: false
           type: array
         taskView:
-          $ref: '#/components/schemas/webhooks.v1.TaskView'
+          oneOf:
+            - $ref: '#/components/schemas/webhooks.v1.TaskView'
+            - type: "null"
       title: Payload Policy Approval Step
       type: object
       x-speakeasy-include: true
@@ -95,7 +103,9 @@ components:
           readOnly: false
           type: array
         taskView:
-          $ref: '#/components/schemas/webhooks.v1.TaskView'
+          oneOf:
+            - $ref: '#/components/schemas/webhooks.v1.TaskView'
+            - type: "null"
       title: Payload Policy Post Action
       type: object
       x-speakeasy-include: true
@@ -118,7 +128,9 @@ components:
           readOnly: false
           type: array
         taskView:
-          $ref: '#/components/schemas/webhooks.v1.TaskView'
+          oneOf:
+            - $ref: '#/components/schemas/webhooks.v1.TaskView'
+            - type: "null"
       title: Payload Provision Step
       type: object
       x-speakeasy-include: true
@@ -135,11 +147,13 @@ components:
         search[decoded]:
           deprecated: true
           description: The search[decoded] field.
+          nullable: true
           readOnly: false
           type: string
           x-sunset: "2025-09-30"
         taskId:
           description: The taskId field.
+          nullable: true
           readOnly: false
           type: string
       title: Task View

--- a/example/webhooks/v1/response.pb.webhooks_v1.oas31.yaml
+++ b/example/webhooks/v1/response.pb.webhooks_v1.oas31.yaml
@@ -6,6 +6,7 @@ components:
       properties:
         policyStepId:
           description: The policyStepId field.
+          nullable: true
           readOnly: false
           type: string
       title: Policy Step
@@ -22,17 +23,26 @@ components:
           - replacePolicy
       properties:
         approve:
-          $ref: '#/components/schemas/webhooks.v1.ResponsePolicyApprovalStep.ResponsePolicyApprovalStepApprove'
+          oneOf:
+            - $ref: '#/components/schemas/webhooks.v1.ResponsePolicyApprovalStep.ResponsePolicyApprovalStepApprove'
+            - type: "null"
         deny:
-          $ref: '#/components/schemas/webhooks.v1.ResponsePolicyApprovalStep.ResponsePolicyApprovalStepDeny'
+          oneOf:
+            - $ref: '#/components/schemas/webhooks.v1.ResponsePolicyApprovalStep.ResponsePolicyApprovalStepDeny'
+            - type: "null"
         reassign:
-          $ref: '#/components/schemas/webhooks.v1.ResponsePolicyApprovalStep.ResponsePolicyApprovalStepReassign'
+          oneOf:
+            - $ref: '#/components/schemas/webhooks.v1.ResponsePolicyApprovalStep.ResponsePolicyApprovalStepReassign'
+            - type: "null"
         replacePolicy:
-          $ref: '#/components/schemas/webhooks.v1.ResponsePolicyApprovalStep.ResponsePolicyApprovalReplacePolicy'
+          oneOf:
+            - $ref: '#/components/schemas/webhooks.v1.ResponsePolicyApprovalStep.ResponsePolicyApprovalReplacePolicy'
+            - type: "null"
         version:
           description: |-
             version contains the constant value "v1". Future versions of the Webhook Response
              will use a different string.
+          nullable: true
           readOnly: false
           type: string
       title: Response Policy Approval Step
@@ -41,10 +51,10 @@ components:
       x-speakeasy-name-override: ResponsePolicyApprovalStep
     webhooks.v1.ResponsePolicyApprovalStep.ResponsePolicyApprovalReplacePolicy:
       description: The ResponsePolicyApprovalReplacePolicy message.
-      nullable: true
       properties:
         comment:
           description: The comment field.
+          nullable: true
           readOnly: false
           type: string
         policySteps:
@@ -59,10 +69,10 @@ components:
       x-speakeasy-name-override: ResponsePolicyApprovalReplacePolicy
     webhooks.v1.ResponsePolicyApprovalStep.ResponsePolicyApprovalStepApprove:
       description: The ResponsePolicyApprovalStepApprove message.
-      nullable: true
       properties:
         comment:
           description: optional comment
+          nullable: true
           readOnly: false
           type: string
       title: Response Policy Approval Step Approve
@@ -70,10 +80,10 @@ components:
       x-speakeasy-name-override: ResponsePolicyApprovalStepApprove
     webhooks.v1.ResponsePolicyApprovalStep.ResponsePolicyApprovalStepDeny:
       description: The ResponsePolicyApprovalStepDeny message.
-      nullable: true
       properties:
         comment:
           description: optional comment
+          nullable: true
           readOnly: false
           type: string
       title: Response Policy Approval Step Deny
@@ -81,10 +91,10 @@ components:
       x-speakeasy-name-override: ResponsePolicyApprovalStepDeny
     webhooks.v1.ResponsePolicyApprovalStep.ResponsePolicyApprovalStepReassign:
       description: The ResponsePolicyApprovalStepReassign message.
-      nullable: true
       properties:
         comment:
           description: optional comment
+          nullable: true
           readOnly: false
           type: string
         newStepUserIds:
@@ -104,6 +114,7 @@ components:
           description: |-
             version contains the constant value "v1". Future versions of the Webhook Response
              will use a different string.
+          nullable: true
           readOnly: false
           type: string
       title: Response Policy Post Action
@@ -119,13 +130,18 @@ components:
           - errored
       properties:
         complete:
-          $ref: '#/components/schemas/webhooks.v1.ResponseProvisionStep.ResponseProvisionStepComplete'
+          oneOf:
+            - $ref: '#/components/schemas/webhooks.v1.ResponseProvisionStep.ResponseProvisionStepComplete'
+            - type: "null"
         errored:
-          $ref: '#/components/schemas/webhooks.v1.ResponseProvisionStep.ResponseProvisionStepErrored'
+          oneOf:
+            - $ref: '#/components/schemas/webhooks.v1.ResponseProvisionStep.ResponseProvisionStepErrored'
+            - type: "null"
         version:
           description: |-
             version contains the constant value "v1". Future versions of the Webhook Response
              will use a different string.
+          nullable: true
           readOnly: false
           type: string
       title: Response Provision Step
@@ -134,10 +150,10 @@ components:
       x-speakeasy-name-override: ResponseProvisionStep
     webhooks.v1.ResponseProvisionStep.ResponseProvisionStepComplete:
       description: The ResponseProvisionStepComplete message.
-      nullable: true
       properties:
         comment:
           description: optional comment
+          nullable: true
           readOnly: false
           type: string
       title: Response Provision Step Complete
@@ -145,10 +161,10 @@ components:
       x-speakeasy-name-override: ResponseProvisionStepComplete
     webhooks.v1.ResponseProvisionStep.ResponseProvisionStepErrored:
       description: The ResponseProvisionStepErrored message.
-      nullable: true
       properties:
         comment:
           description: optional comment
+          nullable: true
           readOnly: false
           type: string
       title: Response Provision Step Errored
@@ -161,6 +177,7 @@ components:
           description: |-
             version contains the constant value "v1". Future versions of the Webhook Response
              will use a different string.
+          nullable: true
           readOnly: false
           type: string
       title: Response Test


### PR DESCRIPTION
Intention of this change:

When you generate a TypeScript SDK with **Speakeasy** from an OpenAPI spec, marking fields as **nullable** isn’t just a stylistic choice — it directly affects how the SDK represents, serializes, and validates those fields.

Here’s why you’d explicitly mark them as nullable in your spec (or overlay):

### 1. Accurately reflect the API’s contract

If the API can **return** `null` for a field, your OpenAPI schema should say so.
Without `nullable: true`, Speakeasy will generate the TypeScript type as if that field can **never** be `null`, which:

- Misleads SDK users
- Can cause runtime errors if the API actually sends null

Example:
```
someField:
  type: string
  nullable: true
```
Generates:
```
someField?: string | null;
```
instead of:
```
someField?: string;
```

### 2. Let SDK consumers handle null explicitly

If you don’t mark it nullable, TypeScript will not require you to handle `null` values.
When the API sends `null` unexpectedly, SDK consumers will either:

- Crash (`Cannot read properties of null`)
- Have to use type assertions, which bypass type safety

Marking nullable forces correct handling:
```
if (obj.someField !== null) {
  // safe to use
}
```

### 3. Correct request serialization

Speakeasy’s generated SDK will treat:

- **Unset field** → omitted from request body
- **Nullable field set to** `null` → explicitly serialized as `null`

This difference matters for PATCH/PUT endpoints where sending `null` **clears** a value in the backend, versus not sending the field at all (no change).

### 4. Prevent subtle bugs with undefined vs null

In TypeScript:

- `undefined` means “not provided”
- `null` means “explicitly no value”

If you don’t mark `nullable`, Speakeasy will only generate the `undefined` case, and your SDK will never serialize `null` — possibly breaking update/delete flows that rely on it.

### 5. Better OpenAPI → SDK consistency

When you later regenerate your SDK from the OpenAPI spec, having `nullable: true` ensures you don’t accidentally change the generated type signature and break existing TypeScript code using the SDK.