### PR TITLE
Use type null option to standarize nullable behavior

### DIFF
--- a/example/bookstore/v1/bookstore.pb.bookstore_service.oas31.yaml
+++ b/example/bookstore/v1/bookstore.pb.bookstore_service.oas31.yaml
@@ -16,9 +16,10 @@ components:
                 type: string
             readOnly: false
             type: object
-          nullable: true
           readOnly: false
-          type: array
+          type:
+            - array
+            - "null"
           x-sunset: "2025-08-15"
         createdAt:
           oneOf:
@@ -28,18 +29,20 @@ components:
             - type: "null"
         firstName:
           description: The firstName field.
-          nullable: true
           readOnly: false
-          type: string
+          type:
+            - string
+            - "null"
         gender:
           description: The gender field.
           enum:
             - GENDER_UNSPECIFIED
             - GENDER_MALE
             - GENDER_FEMALE
-          nullable: true
           readOnly: false
-          type: string
+          type:
+            - string
+            - "null"
           x-speakeasy-unknown-values: allow
         genders:
           description: The genders field.
@@ -50,25 +53,29 @@ components:
               - GENDER_FEMALE
             type: string
             x-speakeasy-unknown-values: allow
-          nullable: true
           readOnly: false
-          type: array
+          type:
+            - array
+            - "null"
         id:
           description: A unique author id.
           format: int64
-          nullable: true
           readOnly: false
-          type: string
+          type:
+            - string
+            - "null"
         lname:
           description: The lname field.
-          nullable: true
           readOnly: false
-          type: string
+          type:
+            - string
+            - "null"
         metadata:
           description: The metadata field.
-          nullable: true
           readOnly: true
-          type: string
+          type:
+            - string
+            - "null"
           x-stability-level: beta
       title: Author
       type: object
@@ -78,9 +85,10 @@ components:
       properties:
         author:
           description: An author of the book.
-          nullable: true
           readOnly: false
-          type: string
+          type:
+            - string
+            - "null"
           x-stability-level: stable
         id:
           description: A unique book id.
@@ -91,22 +99,25 @@ components:
           description: Quotes from the book - this field is in beta.
           items:
             type: string
-          nullable: true
           readOnly: false
-          type: array
+          type:
+            - array
+            - "null"
           x-stability-level: beta
         shelfId:
           deprecated: true
           description: Shelf ID - deprecated, use shelf reference instead
-          nullable: true
           readOnly: false
-          type: string
+          type:
+            - string
+            - "null"
           x-sunset: "2025-09-30"
         title:
           description: A book title.
-          nullable: true
           readOnly: false
-          type: string
+          type:
+            - string
+            - "null"
           x-stability-level: stable
       required:
         - id
@@ -139,9 +150,10 @@ components:
       properties:
         name:
           description: The name field.
-          nullable: true
           readOnly: false
-          type: string
+          type:
+            - string
+            - "null"
       title: Create Genre Request
       type: object
       x-speakeasy-name-override: CreateGenreRequest
@@ -216,15 +228,17 @@ components:
         id:
           description: A unique genre id.
           format: int64
-          nullable: true
           readOnly: false
-          type: string
+          type:
+            - string
+            - "null"
           x-stability-level: alpha
         name:
           description: A genre name.
-          nullable: true
           readOnly: false
-          type: string
+          type:
+            - string
+            - "null"
           x-stability-level: alpha
       title: Genre
       type: object
@@ -248,17 +262,19 @@ components:
             The fiction field.
             This field is part of the `genre` oneof.
             See the documentation for `bookstore.v1.GetAuthorResponse` for more details.
-          nullable: true
           readOnly: false
-          type: boolean
+          type:
+            - boolean
+            - "null"
         nonfiction:
           description: |-
             The nonfiction field.
             This field is part of the `genre` oneof.
             See the documentation for `bookstore.v1.GetAuthorResponse` for more details.
-          nullable: true
           readOnly: false
-          type: boolean
+          type:
+            - boolean
+            - "null"
       title: Get Author Response
       type: object
       x-speakeasy-name-override: GetAuthorResponse
@@ -289,9 +305,10 @@ components:
           description: The books field.
           items:
             $ref: '#/components/schemas/bookstore.v1.Book'
-          nullable: true
           readOnly: false
-          type: array
+          type:
+            - array
+            - "null"
       title: List Books Response
       type: object
       x-speakeasy-name-override: ListBooksResponse
@@ -302,9 +319,10 @@ components:
           description: The genres field.
           items:
             $ref: '#/components/schemas/bookstore.v1.Genre'
-          nullable: true
           readOnly: false
-          type: array
+          type:
+            - array
+            - "null"
       title: List Genres Response
       type: object
       x-speakeasy-name-override: ListGenresResponse
@@ -314,15 +332,18 @@ components:
         mask:
           oneOf:
             - readOnly: false
-              type: string
+              type:
+                - string
+                - "null"
             - type: "null"
         shelves:
           description: Shelves in the bookstore.
           items:
             $ref: '#/components/schemas/bookstore.v1.Shelf'
-          nullable: true
           readOnly: false
-          type: array
+          type:
+            - array
+            - "null"
       title: List Shelves Response
       type: object
       x-speakeasy-name-override: ListShelvesResponse
@@ -331,9 +352,10 @@ components:
       properties:
         anotherProp:
           description: This is a non recursive secondary prop
-          nullable: true
           readOnly: false
-          type: string
+          type:
+            - string
+            - "null"
         page:
           oneOf:
             - $ref: '#/components/schemas/bookstore.v1.RecursivePage'
@@ -352,21 +374,24 @@ components:
           description: This is a list of recursive pages
           items:
             $ref: '#/components/schemas/bookstore.v1.RecursivePage'
-          nullable: true
           readOnly: false
-          type: array
+          type:
+            - array
+            - "null"
         pages:
           description: This is a list of recursive books
           items:
             $ref: '#/components/schemas/bookstore.v1.RecursiveBookResponse'
-          nullable: true
           readOnly: false
-          type: array
+          type:
+            - array
+            - "null"
         prop:
           description: This is a non recursive prop
-          nullable: true
           readOnly: false
-          type: string
+          type:
+            - string
+            - "null"
       title: Recursive Page
       type: object
       x-speakeasy-name-override: RecursivePage
@@ -375,25 +400,29 @@ components:
       properties:
         id:
           description: A unique shelf id.
-          nullable: true
           readOnly: false
-          type: string
+          type:
+            - string
+            - "null"
           x-stability-level: stable
         search%5Bencoded%5D:
           description: To test json name is percentage encoded
-          nullable: true
           readOnly: false
-          type: string
+          type:
+            - string
+            - "null"
         search[decoded]:
           description: To test json name is percentage decoded
-          nullable: true
           readOnly: false
-          type: string
+          type:
+            - string
+            - "null"
         theme:
           description: A theme of the shelf (fiction, poetry, etc).
-          nullable: true
           readOnly: false
-          type: string
+          type:
+            - string
+            - "null"
           x-stability-level: stable
       title: Bookshelf
       type: object
@@ -407,9 +436,10 @@ components:
             - type: "null"
         shelf:
           description: The ID of the shelf from which to retrieve a book.
-          nullable: true
           readOnly: false
-          type: string
+          type:
+            - string
+            - "null"
       title: Update Book Request
       type: object
       x-speakeasy-name-override: UpdateBookRequest
@@ -442,9 +472,10 @@ paths:
           schema:
             description: The ID of the author resource to retrieve.
             format: int64
-            nullable: true
             readOnly: false
-            type: string
+            type:
+              - string
+              - "null"
       responses:
         "200":
           content:
@@ -489,9 +520,10 @@ paths:
           required: true
           schema:
             description: The genreId field.
-            nullable: true
             readOnly: false
-            type: string
+            type:
+              - string
+              - "null"
       requestBody:
         content:
           application/json:
@@ -518,9 +550,10 @@ paths:
           required: true
           schema:
             description: The genreId field.
-            nullable: true
             readOnly: false
-            type: string
+            type:
+              - string
+              - "null"
       responses:
         "200":
           content:
@@ -618,9 +651,10 @@ paths:
           required: true
           schema:
             description: The ID of the shelf to delete.
-            nullable: true
             readOnly: false
-            type: string
+            type:
+              - string
+              - "null"
       requestBody:
         content:
           application/json:
@@ -650,9 +684,10 @@ paths:
           required: true
           schema:
             description: ID of the shelf which books to list.
-            nullable: true
             readOnly: false
-            type: string
+            type:
+              - string
+              - "null"
       responses:
         "200":
           content:
@@ -687,9 +722,10 @@ paths:
           required: true
           schema:
             description: The ID of the shelf on which to create a book.
-            nullable: true
             readOnly: false
-            type: string
+            type:
+              - string
+              - "null"
       requestBody:
         content:
           application/json:
@@ -720,9 +756,10 @@ paths:
           schema:
             deprecated: true
             description: Shelf ID - deprecated, use shelf reference instead
-            nullable: true
             readOnly: false
-            type: string
+            type:
+              - string
+              - "null"
             x-sunset: "2025-09-30"
         - in: path
           name: book
@@ -760,40 +797,45 @@ paths:
           required: true
           schema:
             description: The ID of the shelf from which to retrieve a book.
-            nullable: true
             readOnly: false
-            type: string
+            type:
+              - string
+              - "null"
         - in: path
           name: book
           required: true
           schema:
             description: The ID of the book to retrieve.
             format: int64
-            nullable: true
             readOnly: false
-            type: string
+            type:
+              - string
+              - "null"
         - in: query
           name: author
           schema:
             description: The includeAuthor field.
-            nullable: true
             readOnly: false
-            type: boolean
+            type:
+              - boolean
+              - "null"
         - in: query
           name: page_size
           schema:
             description: The pageSize field.
             format: int32
-            nullable: true
             readOnly: false
-            type: integer
+            type:
+              - integer
+              - "null"
         - in: query
           name: page_token
           schema:
             description: The pageToken field.
-            nullable: true
             readOnly: false
-            type: string
+            type:
+              - string
+              - "null"
       responses:
         "200":
           content:
@@ -819,9 +861,10 @@ paths:
           schema:
             deprecated: true
             description: Shelf ID - deprecated, use shelf reference instead
-            nullable: true
             readOnly: false
-            type: string
+            type:
+              - string
+              - "null"
             x-sunset: "2025-09-30"
         - in: path
           name: book

--- a/example/webhooks/v1/request.pb.webhooks_v1.oas31.yaml
+++ b/example/webhooks/v1/request.pb.webhooks_v1.oas31.yaml
@@ -12,9 +12,10 @@ components:
              If your receiver returns any other status code, it is expected to not use the callback url.
 
              This value will match the "Webhook-Callback-Url" header.
-          nullable: true
           readOnly: false
-          type: string
+          type:
+            - string
+            - "null"
         event:
           description: |-
             The type of event that triggered this Webhook.
@@ -26,9 +27,10 @@ components:
              - "webhooks.v1.PayloadPolicyApprovalStep"
              - "webhooks.v1.PayloadPolicyPostAction"
              - "webhooks.v1.PayloadProvisionStep"
-          nullable: true
           readOnly: false
-          type: string
+          type:
+            - string
+            - "null"
         payload:
           oneOf:
             - additionalProperties: true
@@ -45,17 +47,19 @@ components:
             version contains the constant value "v1". Future versions of the Webhook body will use a different string.
 
              This value will match the "Webhook-Version" header.
-          nullable: true
           readOnly: false
-          type: string
+          type:
+            - string
+            - "null"
         webhookId:
           description: |-
             Unique ID for this Webhook. Your receiver should only process this ID once.
 
              This value will match the "Webhook-Id" header.
-          nullable: true
           readOnly: false
-          type: string
+          type:
+            - string
+            - "null"
       title: Body
       type: object
       x-speakeasy-include: true
@@ -74,9 +78,10 @@ components:
                 type: string
             readOnly: false
             type: object
-          nullable: true
           readOnly: false
-          type: array
+          type:
+            - array
+            - "null"
         taskView:
           oneOf:
             - $ref: '#/components/schemas/webhooks.v1.TaskView'
@@ -99,9 +104,10 @@ components:
                 type: string
             readOnly: false
             type: object
-          nullable: true
           readOnly: false
-          type: array
+          type:
+            - array
+            - "null"
         taskView:
           oneOf:
             - $ref: '#/components/schemas/webhooks.v1.TaskView'
@@ -124,9 +130,10 @@ components:
                 type: string
             readOnly: false
             type: object
-          nullable: true
           readOnly: false
-          type: array
+          type:
+            - array
+            - "null"
         taskView:
           oneOf:
             - $ref: '#/components/schemas/webhooks.v1.TaskView'
@@ -147,15 +154,17 @@ components:
         search[decoded]:
           deprecated: true
           description: The search[decoded] field.
-          nullable: true
           readOnly: false
-          type: string
+          type:
+            - string
+            - "null"
           x-sunset: "2025-09-30"
         taskId:
           description: The taskId field.
-          nullable: true
           readOnly: false
-          type: string
+          type:
+            - string
+            - "null"
       title: Task View
       type: object
       x-speakeasy-name-override: TaskView

--- a/example/webhooks/v1/response.pb.webhooks_v1.oas31.yaml
+++ b/example/webhooks/v1/response.pb.webhooks_v1.oas31.yaml
@@ -6,9 +6,10 @@ components:
       properties:
         policyStepId:
           description: The policyStepId field.
-          nullable: true
           readOnly: false
-          type: string
+          type:
+            - string
+            - "null"
       title: Policy Step
       type: object
       x-speakeasy-name-override: PolicyStep
@@ -42,9 +43,10 @@ components:
           description: |-
             version contains the constant value "v1". Future versions of the Webhook Response
              will use a different string.
-          nullable: true
           readOnly: false
-          type: string
+          type:
+            - string
+            - "null"
       title: Response Policy Approval Step
       type: object
       x-speakeasy-include: true
@@ -54,16 +56,18 @@ components:
       properties:
         comment:
           description: The comment field.
-          nullable: true
           readOnly: false
-          type: string
+          type:
+            - string
+            - "null"
         policySteps:
           description: The policySteps field.
           items:
             $ref: '#/components/schemas/webhooks.v1.PolicyStep'
-          nullable: true
           readOnly: false
-          type: array
+          type:
+            - array
+            - "null"
       title: Response Policy Approval Replace Policy
       type: object
       x-speakeasy-name-override: ResponsePolicyApprovalReplacePolicy
@@ -72,9 +76,10 @@ components:
       properties:
         comment:
           description: optional comment
-          nullable: true
           readOnly: false
-          type: string
+          type:
+            - string
+            - "null"
       title: Response Policy Approval Step Approve
       type: object
       x-speakeasy-name-override: ResponsePolicyApprovalStepApprove
@@ -83,9 +88,10 @@ components:
       properties:
         comment:
           description: optional comment
-          nullable: true
           readOnly: false
-          type: string
+          type:
+            - string
+            - "null"
       title: Response Policy Approval Step Deny
       type: object
       x-speakeasy-name-override: ResponsePolicyApprovalStepDeny
@@ -94,16 +100,18 @@ components:
       properties:
         comment:
           description: optional comment
-          nullable: true
           readOnly: false
-          type: string
+          type:
+            - string
+            - "null"
         newStepUserIds:
           description: The newStepUserIds field.
           items:
             type: string
-          nullable: true
           readOnly: false
-          type: array
+          type:
+            - array
+            - "null"
       title: Response Policy Approval Step Reassign
       type: object
       x-speakeasy-name-override: ResponsePolicyApprovalStepReassign
@@ -114,9 +122,10 @@ components:
           description: |-
             version contains the constant value "v1". Future versions of the Webhook Response
              will use a different string.
-          nullable: true
           readOnly: false
-          type: string
+          type:
+            - string
+            - "null"
       title: Response Policy Post Action
       type: object
       x-speakeasy-include: true
@@ -141,9 +150,10 @@ components:
           description: |-
             version contains the constant value "v1". Future versions of the Webhook Response
              will use a different string.
-          nullable: true
           readOnly: false
-          type: string
+          type:
+            - string
+            - "null"
       title: Response Provision Step
       type: object
       x-speakeasy-include: true
@@ -153,9 +163,10 @@ components:
       properties:
         comment:
           description: optional comment
-          nullable: true
           readOnly: false
-          type: string
+          type:
+            - string
+            - "null"
       title: Response Provision Step Complete
       type: object
       x-speakeasy-name-override: ResponseProvisionStepComplete
@@ -164,9 +175,10 @@ components:
       properties:
         comment:
           description: optional comment
-          nullable: true
           readOnly: false
-          type: string
+          type:
+            - string
+            - "null"
       title: Response Provision Step Errored
       type: object
       x-speakeasy-name-override: ResponseProvisionStepErrored
@@ -177,9 +189,10 @@ components:
           description: |-
             version contains the constant value "v1". Future versions of the Webhook Response
              will use a different string.
-          nullable: true
           readOnly: false
-          type: string
+          type:
+            - string
+            - "null"
       title: Response Test
       type: object
       x-speakeasy-include: true

--- a/internal/apigw/apigw_openapi_schema.go
+++ b/internal/apigw/apigw_openapi_schema.go
@@ -105,7 +105,7 @@ func (sc *schemaContainer) Message(m pgs.Message, filter []string, nullable *boo
 		// but right now WKTs are just rendered inline, and not a Ref.
 		s := sc.schemaForWKT(WellKnownType(m))
 		s.ReadOnly = &readOnly
-		s.Nullable = nullable
+		mergeNullable(s, nullable)
 		return dm_base.CreateSchemaProxy(s)
 	}
 
@@ -291,11 +291,11 @@ func (sc *schemaContainer) Field(f pgs.Field) *dm_base.SchemaProxy {
 		arraySchema := &dm_base.Schema{
 			Type:        []string{"array"},
 			Description: description,
-			Nullable:    nullable,
 			ReadOnly:    &readOnly,
 			Deprecated:  deprecated,
 			Items:       &dm_base.DynamicValue[*dm_base.SchemaProxy, bool]{A: fteSchema},
 		}
+		mergeNullable(arraySchema, nullable)
 		// Add extensions if any exist
 		if extensions.Len() > 0 {
 			arraySchema.Extensions = extensions
@@ -307,10 +307,10 @@ func (sc *schemaContainer) Field(f pgs.Field) *dm_base.SchemaProxy {
 			Type:                 []string{"object"},
 			Deprecated:           deprecated,
 			Description:          description,
-			Nullable:             nullable,
 			ReadOnly:             &readOnly,
 			AdditionalProperties: &dm_base.DynamicValue[*dm_base.SchemaProxy, bool]{A: fteSchema},
 		}
+		mergeNullable(mv, nullable)
 		// Add extensions if any exist
 		if extensions.Len() > 0 {
 			mv.Extensions = extensions
@@ -350,7 +350,7 @@ func (sc *schemaContainer) Field(f pgs.Field) *dm_base.SchemaProxy {
 	default:
 		sv := sc.schemaForScalar(f.Type().ProtoType())
 		sv.ReadOnly = &readOnly
-		sv.Nullable = nullable
+		mergeNullable(sv, nullable)
 		sv.Deprecated = deprecated
 		sv.Description = description
 		// Add extensions if any exist
@@ -432,7 +432,17 @@ func mergeNullable(s *dm_base.Schema, nullable *bool) {
 	if nullable == nil || !*nullable {
 		return
 	}
-	if *nullable {
-		s.Nullable = oasTrue()
+	addNullType(s)
+}
+
+func addNullType(s *dm_base.Schema) {
+	if s == nil {
+		return
 	}
+	// ensure "null" appears in the schema type list
+	if !contains("null", s.Type) {
+		s.Type = append(s.Type, "null")
+	}
+	// clear legacy nullable usage
+	s.Nullable = nil
 }

--- a/internal/apigw/apigw_openapi_wkt.go
+++ b/internal/apigw/apigw_openapi_wkt.go
@@ -31,8 +31,7 @@ func (sc *schemaContainer) schemaForWKT(wkt pgs.WellKnownType) *dm_base.Schema {
 		}
 	case pgs.EmptyWKT:
 		return &dm_base.Schema{
-			Type:     []string{"object"},
-			Nullable: oasTrue(),
+			Type: []string{"object", "null"},
 		}
 	case pgs.StructWKT:
 		// todo: pquerna: is this the right mapping for an arbitrary Struct?
@@ -47,70 +46,58 @@ func (sc *schemaContainer) schemaForWKT(wkt pgs.WellKnownType) *dm_base.Schema {
 		}
 	case pgs.ValueWKT:
 		return &dm_base.Schema{
-			Type:     []string{"string", "number", "object", "array", "boolean", "null"},
-			Nullable: oasTrue(),
+			Type: []string{"string", "number", "object", "array", "boolean", "null"},
 		}
 	case pgs.ListValueWKT:
 		return &dm_base.Schema{
-			Type:     []string{"array"},
-			Nullable: oasTrue(),
+			Type: []string{"array", "null"},
 		}
 	case pgs.DoubleValueWKT:
 		return &dm_base.Schema{
-			Type:     []string{"number"},
-			Format:   "double",
-			Nullable: oasTrue(),
+			Type:   []string{"number", "null"},
+			Format: "double",
 		}
 	case pgs.FloatValueWKT:
 		return &dm_base.Schema{
-			Type:     []string{"number"},
-			Format:   "float",
-			Nullable: oasTrue(),
+			Type:   []string{"number", "null"},
+			Format: "float",
 		}
 	case pgs.Int64ValueWKT:
 		return &dm_base.Schema{
-			Type:     []string{"string"},
-			Format:   "int64",
-			Nullable: oasTrue(),
+			Type:   []string{"string", "null"},
+			Format: "int64",
 		}
 	case pgs.UInt64ValueWKT:
 		return &dm_base.Schema{
-			Type:     []string{"string"},
-			Format:   "uint64",
-			Nullable: oasTrue(),
+			Type:   []string{"string", "null"},
+			Format: "uint64",
 		}
 	case pgs.Int32ValueWKT:
 		return &dm_base.Schema{
-			Type:     []string{"integer"},
-			Format:   "int32",
-			Nullable: oasTrue(),
+			Type:   []string{"integer", "null"},
+			Format: "int32",
 		}
 	case pgs.UInt32ValueWKT:
 		return &dm_base.Schema{
-			Type:     []string{"integer"},
-			Format:   "int64",
-			Nullable: oasTrue(),
+			Type:   []string{"integer", "null"},
+			Format: "int64",
 		}
 	case pgs.BoolValueWKT:
 		return &dm_base.Schema{
-			Type:     []string{"boolean"},
-			Nullable: oasTrue(),
+			Type: []string{"boolean", "null"},
 		}
 	case pgs.StringValueWKT:
 		return &dm_base.Schema{
-			Type:     []string{"string"},
-			Nullable: oasTrue(),
+			Type: []string{"string", "null"},
 		}
 	case pgs.BytesValueWKT:
 		return &dm_base.Schema{
-			Type:     []string{"string"},
-			Format:   "bytes",
-			Nullable: oasTrue(),
+			Type:   []string{"string", "null"},
+			Format: "bytes",
 		}
 	case FieldMaskWKT:
 		return &dm_base.Schema{
-			Type:     []string{"string"},
-			Nullable: oasTrue(),
+			Type: []string{"string", "null"},
 		}
 	case pgs.UnknownWKT:
 		// TODO: handle these.. if any are really needed


### PR DESCRIPTION
This change standardize the openapi definition to match openAPI 3.1.x expected standards: https://www.speakeasy.com/openapi/schemas/null#openapi-v31