### PR TITLE
x-speakeasy-entity-missing-codes: 404

### DIFF
--- a/internal/apigw/apigw_openapi.go
+++ b/internal/apigw/apigw_openapi.go
@@ -282,6 +282,7 @@ func (module *Module) buildOperation(ctx pgsgo.Context, method pgs.Method, mt *m
 	if terraformEntity != nil {
 		// Set the extension
 		extensions.Set("x-speakeasy-entity-operation", terraformEntity)
+		extensions.Set("x-speakeasy-entity-missing-codes", yamlStringSlice([]string{"404"}))
 	}
 
 	// Get pagination values


### PR DESCRIPTION
Add x-speakeasy-entity-missing-codes everywhere an x-speakeasy-entity-operation is set