### PR TITLE
RFR: Fix x-speakeasy-entity-missing-codes emitting string instead of int

### DIFF
--- a/internal/apigw/apigw_openapi.go
+++ b/internal/apigw/apigw_openapi.go
@@ -282,7 +282,7 @@ func (module *Module) buildOperation(ctx pgsgo.Context, method pgs.Method, mt *m
 	if terraformEntity != nil {
 		// Set the extension
 		extensions.Set("x-speakeasy-entity-operation", terraformEntity)
-		extensions.Set("x-speakeasy-entity-missing-codes", yamlStringSlice([]string{"404"}))
+		extensions.Set("x-speakeasy-entity-missing-codes", yamlIntSlice([]int{404}))
 	}
 
 	// Get pagination values

--- a/internal/apigw/apigw_openapi_schema.go
+++ b/internal/apigw/apigw_openapi_schema.go
@@ -79,11 +79,30 @@ func yamlString(in string) *yaml.Node {
 	return rv
 }
 
+func yamlInt(in int) *yaml.Node {
+	return &yaml.Node{
+		Kind:  yaml.ScalarNode,
+		Tag:   "!!int",
+		Value: strconv.Itoa(in),
+	}
+}
+
 func yamlBool(in bool) *yaml.Node {
 	return &yaml.Node{
 		Kind:  yaml.ScalarNode,
 		Tag:   "!!bool",
 		Value: strconv.FormatBool(in),
+	}
+}
+
+func yamlIntSlice(in []int) *yaml.Node {
+	inner := make([]*yaml.Node, 0, len(in))
+	for _, v := range in {
+		inner = append(inner, yamlInt(v))
+	}
+	return &yaml.Node{
+		Kind:    yaml.SequenceNode,
+		Content: inner,
 	}
 }
 


### PR DESCRIPTION
The yamlStringSlice helper was wrapping 404 in quotes, producing "404" (!!str) in the OpenAPI YAML. Speakeasy 1.658.1 expects an integer and fails validation on the string form. Added yamlInt and yamlIntSlice helpers and switched the call site to use them.
