### PR TITLE
feat(openapi): emit nullable $ref for singular message fields

### DIFF
--- a/example/bookstore/v1/bookstore.pb.bookstore_service.oas31.yaml
+++ b/example/bookstore/v1/bookstore.pb.bookstore_service.oas31.yaml
@@ -108,7 +108,9 @@ components:
       description: Request message for CreateBook method.
       properties:
         book:
-          $ref: '#/components/schemas/bookstore.v1.Book'
+          oneOf:
+            - $ref: '#/components/schemas/bookstore.v1.Book'
+            - type: "null"
       title: Create Book Request
       type: object
       x-speakeasy-name-override: CreateBookRequest
@@ -116,7 +118,9 @@ components:
       description: The CreateBookResponse message.
       properties:
         book:
-          $ref: '#/components/schemas/bookstore.v1.Book'
+          oneOf:
+            - $ref: '#/components/schemas/bookstore.v1.Book'
+            - type: "null"
       title: Create Book Response
       type: object
       x-speakeasy-name-override: CreateBookResponse
@@ -133,7 +137,9 @@ components:
       description: The CreateGenreResponse message.
       properties:
         genre:
-          $ref: '#/components/schemas/bookstore.v1.Genre'
+          oneOf:
+            - $ref: '#/components/schemas/bookstore.v1.Genre'
+            - type: "null"
       title: Create Genre Response
       type: object
       x-speakeasy-name-override: CreateGenreResponse
@@ -141,7 +147,9 @@ components:
       description: Request message for CreateShelf method.
       properties:
         shelf:
-          $ref: '#/components/schemas/bookstore.v1.Shelf'
+          oneOf:
+            - $ref: '#/components/schemas/bookstore.v1.Shelf'
+            - type: "null"
       title: Create Shelf Request
       type: object
       x-speakeasy-name-override: CreateShelfRequest
@@ -149,7 +157,9 @@ components:
       description: The CreateShelfResponse message.
       properties:
         shelf:
-          $ref: '#/components/schemas/bookstore.v1.Shelf'
+          oneOf:
+            - $ref: '#/components/schemas/bookstore.v1.Shelf'
+            - type: "null"
       title: Create Shelf Response
       type: object
       x-speakeasy-name-override: CreateShelfResponse
@@ -157,7 +167,9 @@ components:
       description: Request message for DeleteBook method.
       properties:
         book:
-          $ref: '#/components/schemas/bookstore.v1.Book'
+          oneOf:
+            - $ref: '#/components/schemas/bookstore.v1.Book'
+            - type: "null"
       title: Delete Book Request
       type: object
       x-speakeasy-name-override: DeleteBookRequest
@@ -212,7 +224,9 @@ components:
           - nonfiction
       properties:
         author:
-          $ref: '#/components/schemas/bookstore.v1.Author'
+          oneOf:
+            - $ref: '#/components/schemas/bookstore.v1.Author'
+            - type: "null"
         fiction:
           description: |-
             The fiction field.
@@ -236,7 +250,9 @@ components:
       description: The GetBookResponse message.
       properties:
         book:
-          $ref: '#/components/schemas/bookstore.v1.Book'
+          oneOf:
+            - $ref: '#/components/schemas/bookstore.v1.Book'
+            - type: "null"
       title: Get Book Response
       type: object
       x-speakeasy-name-override: GetBookResponse
@@ -244,7 +260,9 @@ components:
       description: The GetGenreResponse message.
       properties:
         genre:
-          $ref: '#/components/schemas/bookstore.v1.Genre'
+          oneOf:
+            - $ref: '#/components/schemas/bookstore.v1.Genre'
+            - type: "null"
       title: Get Genre Response
       type: object
       x-speakeasy-name-override: GetGenreResponse
@@ -298,7 +316,9 @@ components:
           description: This is a non recursive secondary prop
           type: string
         page:
-          $ref: '#/components/schemas/bookstore.v1.RecursivePage'
+          oneOf:
+            - $ref: '#/components/schemas/bookstore.v1.RecursivePage'
+            - type: "null"
       title: Recursive Book Response
       type: object
       x-speakeasy-name-override: RecursiveBookResponse
@@ -306,7 +326,9 @@ components:
       description: A recursive page for the recursive response
       properties:
         books:
-          $ref: '#/components/schemas/bookstore.v1.RecursiveBookResponse'
+          oneOf:
+            - $ref: '#/components/schemas/bookstore.v1.RecursiveBookResponse'
+            - type: "null"
         extraPages:
           description: This is a list of recursive pages
           items:
@@ -351,7 +373,9 @@ components:
       description: Request message for UpdateBook method
       properties:
         book:
-          $ref: '#/components/schemas/bookstore.v1.Book'
+          oneOf:
+            - $ref: '#/components/schemas/bookstore.v1.Book'
+            - type: "null"
         shelf:
           description: The ID of the shelf from which to retrieve a book.
           type: string
@@ -362,7 +386,9 @@ components:
       description: The UpdateBookResponse message.
       properties:
         book:
-          $ref: '#/components/schemas/bookstore.v1.Book'
+          oneOf:
+            - $ref: '#/components/schemas/bookstore.v1.Book'
+            - type: "null"
       title: Update Book Response
       type: object
       x-speakeasy-name-override: UpdateBookResponse

--- a/example/webhooks/v1/request.pb.webhooks_v1.oas31.yaml
+++ b/example/webhooks/v1/request.pb.webhooks_v1.oas31.yaml
@@ -66,7 +66,9 @@ components:
             - array
             - "null"
         taskView:
-          $ref: '#/components/schemas/webhooks.v1.TaskView'
+          oneOf:
+            - $ref: '#/components/schemas/webhooks.v1.TaskView'
+            - type: "null"
       title: Payload Policy Approval Step
       type: object
       x-speakeasy-include: true
@@ -88,7 +90,9 @@ components:
             - array
             - "null"
         taskView:
-          $ref: '#/components/schemas/webhooks.v1.TaskView'
+          oneOf:
+            - $ref: '#/components/schemas/webhooks.v1.TaskView'
+            - type: "null"
       title: Payload Policy Post Action
       type: object
       x-speakeasy-include: true
@@ -110,7 +114,9 @@ components:
             - array
             - "null"
         taskView:
-          $ref: '#/components/schemas/webhooks.v1.TaskView'
+          oneOf:
+            - $ref: '#/components/schemas/webhooks.v1.TaskView'
+            - type: "null"
       title: Payload Provision Step
       type: object
       x-speakeasy-include: true

--- a/internal/apigw/apigw_openapi_schema.go
+++ b/internal/apigw/apigw_openapi_schema.go
@@ -385,13 +385,14 @@ func (sc *schemaContainer) Field(f pgs.Field) *dm_base.SchemaProxy {
 		// todo: nested filters
 		ref := sc.Message(f.Type().Embed(), nil, readOnly, false)
 		// Well-known types are rendered inline (not as a $ref) and are not
-		// marked nullable here, preserving prior behavior. Message $refs that
-		// have field presence (proto3 optional / oneof members) are wrapped so
-		// they may also be null, the 3.1 way.
-		if nullable != nil && *nullable && !IsWellKnown(f.Type().Embed()) {
-			return nullableRef(ref)
+		// marked nullable here, preserving prior behavior. Every other singular
+		// message field has presence in proto3, and the JSON API returns null
+		// when it is unset, so wrap the $ref so the schema admits null the 3.1
+		// way (oneOf: [ <ref>, { type: "null" } ]).
+		if IsWellKnown(f.Type().Embed()) {
+			return ref
 		}
-		return ref
+		return nullableRef(ref)
 	default:
 		sv := sc.schemaForScalar(f.Type().ProtoType())
 		sv.ReadOnly = oasReadOnly(readOnly)

--- a/internal/apigw/schema_determinism_test.go
+++ b/internal/apigw/schema_determinism_test.go
@@ -447,13 +447,14 @@ func TestSchemaDeterminism_ConnectorRef(t *testing.T) {
 			t.Errorf("ConnectorRef definition should never be nullable regardless of order; got %v and %v", nullable1, nullable2)
 		}
 
-		// Use-site nullability is correct: the oneof member is nullable, the
-		// non-oneof reference is not.
+		// Use-site nullability: every singular message reference is nullable
+		// (proto3 message fields have presence and the JSON API returns null
+		// when unset), whether or not the field is a oneof member.
 		if !propertyIsNullable(sc2, "test.v1.ConnectorAction", "connectorRef") {
 			t.Error("ConnectorAction.connectorRef (oneof member) should be nullable at the use site")
 		}
-		if propertyIsNullable(sc2, "test.v1.AccountLifecycleAction", "connectorRef") {
-			t.Error("AccountLifecycleAction.connectorRef (non-oneof) should not be nullable")
+		if !propertyIsNullable(sc2, "test.v1.AccountLifecycleAction", "connectorRef") {
+			t.Error("AccountLifecycleAction.connectorRef (singular message) should be nullable at the use site")
 		}
 	})
 
@@ -516,13 +517,14 @@ func TestSchemaDeterminism_UserRef(t *testing.T) {
 			t.Errorf("UserRef definition should never be nullable regardless of order; got %v and %v", nullable1, nullable2)
 		}
 
-		// Use-site nullability is correct: the oneof member is nullable, the
-		// non-oneof reference is not.
+		// Use-site nullability: every singular message reference is nullable
+		// (proto3 message fields have presence and the JSON API returns null
+		// when unset), whether or not the field is a oneof member.
 		if !propertyIsNullable(sc1, "test.v1.UpdateUser", "userRef") {
 			t.Error("UpdateUser.userRef (oneof member) should be nullable at the use site")
 		}
-		if propertyIsNullable(sc1, "test.v1.CreateRevokeTasks", "userRef") {
-			t.Error("CreateRevokeTasks.userRef (non-oneof) should not be nullable")
+		if !propertyIsNullable(sc1, "test.v1.CreateRevokeTasks", "userRef") {
+			t.Error("CreateRevokeTasks.userRef (singular message) should be nullable at the use site")
 		}
 	})
 


### PR DESCRIPTION
Builds on #78. That change moved the spec onto valid OpenAPI 3.1 nullability, but only wrapped a message `$ref` in `oneOf: [ <ref>, { type: "null" } ]` when the field carried an explicit presence marker — a proto3 `optional` field or a `oneof` member.

A **plain singular message field** emitted a bare `$ref`:

```proto
SomeMessage some_field = 1;   // no `optional`, not in a oneof
```

```yaml
someField:
  $ref: "#/components/schemas/SomeMessage"   # not nullable
```

But proto3 singular message fields always have presence, and the JSON API returns `null` for one that is unset. So an SDK generated from the spec models the field as non-nullable and rejects the `null` the API actually returns — a response-validation failure on a perfectly valid response.

## Change

Wrap every singular non-well-known message field’s `$ref` as nullable, regardless of an explicit presence marker:

```yaml
someField:
  oneOf:
    - $ref: "#/components/schemas/SomeMessage"
    - type: "null"
```

- Well-known types stay inline and unchanged (preserves prior behavior).
- Repeated (`["array","null"]`) and map fields are unaffected.
- Message *definitions* remain non-nullable; only the use-site (`$ref`) is wrapped.

## Tests
- Updated `schema_determinism_test.go`: singular non-oneof message references are now expected nullable at the use site (the definition-never-nullable invariant is unchanged).
- Regenerated `example/` goldens; the diff is exactly bare-`$ref` → `oneOf:[$ref,null]` for singular message fields (e.g. `book`, `genre`, `shelf`).
- `go test ./... ./example/...` green. `speakeasy validate` on the regenerated example shows no new errors (the one pre-existing `x-speakeasy-pagination` error and the optional-request-body warnings are present on `main` too).