### PR TITLE
feat(openapi): emit nullable inline schema for singular well-known-type fields

### DIFF
--- a/example/bookstore/v1/bookstore.pb.bookstore_service.oas31.yaml
+++ b/example/bookstore/v1/bookstore.pb.bookstore_service.oas31.yaml
@@ -22,7 +22,9 @@ components:
         createdAt:
           format: date-time
           readOnly: true
-          type: string
+          type:
+            - string
+            - "null"
         firstName:
           description: The firstName field.
           type: string

--- a/example/webhooks/v1/request.pb.webhooks_v1.oas31.yaml
+++ b/example/webhooks/v1/request.pb.webhooks_v1.oas31.yaml
@@ -32,7 +32,9 @@ components:
             '@type':
               description: The type of the serialized message.
               type: string
-          type: object
+          type:
+            - object
+            - "null"
         version:
           description: |-
             version contains the constant value "v1". Future versions of the Webhook body will use a different string.

--- a/internal/apigw/apigw_openapi_schema.go
+++ b/internal/apigw/apigw_openapi_schema.go
@@ -383,15 +383,27 @@ func (sc *schemaContainer) Field(f pgs.Field) *dm_base.SchemaProxy {
 		return dm_base.CreateSchemaProxy(ev)
 	case f.Type().IsEmbed():
 		// todo: nested filters
-		ref := sc.Message(f.Type().Embed(), nil, readOnly, false)
-		// Well-known types are rendered inline (not as a $ref) and are not
-		// marked nullable here, preserving prior behavior. Every other singular
-		// message field has presence in proto3, and the JSON API returns null
-		// when it is unset, so wrap the $ref so the schema admits null the 3.1
-		// way (oneOf: [ <ref>, { type: "null" } ]).
-		if IsWellKnown(f.Type().Embed()) {
-			return ref
+		embed := f.Type().Embed()
+		// Singular message fields have presence in proto3, and the JSON API
+		// returns null when one is unset. The schema must admit that null, or
+		// an SDK generated from the spec rejects the null the API returns.
+		if IsWellKnown(embed) {
+			// Well-known types are rendered inline rather than as a $ref, so
+			// they can't be wrapped with nullableRef. Instead, add "null" to
+			// the inline type union directly (e.g. google.protobuf.Struct ->
+			// type: [object, null]). Several WKTs (Empty, Value, the wrapper
+			// types, FieldMask, ...) already include "null"; this is a no-op
+			// for those.
+			s := sc.schemaForWKT(WellKnownType(embed))
+			s.ReadOnly = oasReadOnly(readOnly)
+			if !slices.Contains(s.Type, "null") {
+				s.Type = append(s.Type, "null")
+			}
+			return dm_base.CreateSchemaProxy(s)
 		}
+		// Other message fields are emitted as a $ref, wrapped so the schema
+		// admits null the 3.1 way (oneOf: [ <ref>, { type: "null" } ]).
+		ref := sc.Message(embed, nil, readOnly, false)
 		return nullableRef(ref)
 	default:
 		sv := sc.schemaForScalar(f.Type().ProtoType())

--- a/internal/apigw/schema_determinism_test.go
+++ b/internal/apigw/schema_determinism_test.go
@@ -133,6 +133,17 @@ func (m *mockMessage) Extension(_ *proto.ExtensionDesc, _ interface{}) (bool, er
 	return false, nil
 }
 
+// mockWKTMessage implements pgs.Message for a well-known type (e.g.
+// google.protobuf.Struct or Timestamp). IsWellKnown reports true and
+// WellKnownType returns the configured WKT, so Field() renders it inline.
+type mockWKTMessage struct {
+	mockMessage
+	wkt pgs.WellKnownType
+}
+
+func (m *mockWKTMessage) IsWellKnown() bool                { return true }
+func (m *mockWKTMessage) WellKnownType() pgs.WellKnownType { return m.wkt }
+
 // Helper constructors
 
 func newMockDescriptorProto() *descriptor.DescriptorProto {
@@ -242,6 +253,44 @@ func TestProto3OptionalNullable(t *testing.T) {
 			t.Errorf("proto3 optional field should NOT have oneof documentation, got: %s", schema.Description)
 		}
 	})
+}
+
+// TestWellKnownSingularFieldNullable verifies that a singular well-known-type
+// message field is rendered nullable. WKTs render inline rather than as a $ref,
+// so they can't be wrapped with oneOf+null; instead "null" is added to the
+// inline type union (e.g. google.protobuf.Struct -> type: [object, null]).
+//
+// A singular message field has presence in proto3, and the JSON API returns
+// null when it is unset; without "null" in the type union an SDK generated from
+// the spec rejects that null during response validation.
+func TestWellKnownSingularFieldNullable(t *testing.T) {
+	parent := &mockMessage{
+		name:   "TestMessage",
+		fqn:    ".test.v1.TestMessage",
+		descPB: newMockDescriptorProto(),
+	}
+
+	cases := []struct {
+		name string
+		wkt  pgs.WellKnownType
+	}{
+		{"struct_object", pgs.StructWKT},
+		{"timestamp_string", pgs.TimestampWKT},
+		{"duration_string", pgs.DurationWKT},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sc := newSchemaContainer()
+			wkt := &mockWKTMessage{wkt: tc.wkt}
+			field := newEmbedField("wktField", parent, wkt, nil)
+
+			schema := sc.Field(field).Schema()
+			if !schemaIsNullable(schema) {
+				t.Errorf("singular %s field should be nullable, got type %v", tc.name, schema.Type)
+			}
+		})
+	}
 }
 
 // TestProto3OptionalFieldEmitted verifies that Message() includes proto3 optional


### PR DESCRIPTION
## Background

#79 made singular **non-well-known** message `$ref` fields nullable (`oneOf: [<ref>, {type: "null"}]`), because proto3 singular message fields have presence and the JSON API returns `null` when one is unset. It deliberately left well-known types alone — they render *inline* (not as a `$ref`), so they kept a non-null type union.

That left a gap. A singular WKT field has the **same** presence semantics: the API returns `null` when it is unset. With `null` missing from the inline type union, an SDK generated from the spec rejects that null during response validation.

Concretely, `google.protobuf.Struct` emitted:

```yaml
profile:
  type: object        # no "null" — rejects the null the API returns
```

So a `null` Struct field (the common case for an unset JSONB message field) fails Speakeasy/Zod response validation and crashes the whole call. The same applies to `Any`, `Timestamp`, and `Duration`.

## Change

For a singular embedded **well-known** field, `Field()` now renders the inline schema and adds `"null"` to its type union instead of returning it bare:

```yaml
profile:
  type: [object, "null"]
createdAt:
  format: date-time
  type: [string, "null"]
```

- WKTs that already admit null — `Empty`, `Value`, `ListValue`, the wrapper types (`*Value`), `FieldMask` — are a no-op.
- Repeated and map fields are unaffected (array/map nullability is handled separately; elements stay non-null).
- Message *definitions* are untouched; only the singular use-site type union changes.

## Tests

- New `TestWellKnownSingularFieldNullable` asserts singular `Struct` / `Timestamp` / `Duration` fields are nullable.
- Regenerated example goldens: `bookstore` `createdAt` (`Timestamp`) and `webhooks` `Any` field now carry `null` in their type union.
- `go test ./... ./example/...` green.

## Why it matters

This is the proper, systemic counterpart to #79: it closes the *entire* class of "API returns null for an unset singular message field, but the generated schema forbids it" for well-known types, so SDKs regenerated from the spec stop needing a hand-maintained nullability overlay for these fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)