### PR TITLE
Regenerate apigw.pb.go against the trimmed DelegationMeta schema

### DIFF
--- a/apigw/v1/apigw.pb.go
+++ b/apigw/v1/apigw.pb.go
@@ -77,10 +77,12 @@ func (Stability) EnumDescriptor() ([]byte, []int) {
 	return file_apigw_v1_apigw_proto_rawDescGZIP(), []int{0}
 }
 
-// Severity tier for AI-guardrail risk scoring. Aligned with NIST FIPS 199
-// (LOW / MODERATE / HIGH), with an additional CRITICAL tier used by
-// ductone/mcp-axiomatic for incident-grade risk. MEDIUM corresponds to
-// FIPS 199 "MODERATE".
+// Severity tier for AI-guardrail risk scoring. Three named levels
+// matching the lethal-trifecta cube's per-axis design (3×3×3 = 27
+// cells; see pkg/aigov/cube in ductone/c1). LOW / MEDIUM / HIGH map
+// to cube Score 0 / 1 / 2. SEVERITY_UNSPECIFIED indicates the field
+// was not set — downstream consumers should treat unset as the
+// conservative default per their policy.
 type Severity int32
 
 const (
@@ -88,7 +90,6 @@ const (
 	Severity_SEVERITY_LOW         Severity = 1
 	Severity_SEVERITY_MEDIUM      Severity = 2
 	Severity_SEVERITY_HIGH        Severity = 3
-	Severity_SEVERITY_CRITICAL    Severity = 4
 )
 
 // Enum value maps for Severity.
@@ -98,14 +99,12 @@ var (
 		1: "SEVERITY_LOW",
 		2: "SEVERITY_MEDIUM",
 		3: "SEVERITY_HIGH",
-		4: "SEVERITY_CRITICAL",
 	}
 	Severity_value = map[string]int32{
 		"SEVERITY_UNSPECIFIED": 0,
 		"SEVERITY_LOW":         1,
 		"SEVERITY_MEDIUM":      2,
 		"SEVERITY_HIGH":        3,
-		"SEVERITY_CRITICAL":    4,
 	}
 )
 
@@ -134,129 +133,6 @@ func (x Severity) Number() protoreflect.EnumNumber {
 // Deprecated: Use Severity.Descriptor instead.
 func (Severity) EnumDescriptor() ([]byte, []int) {
 	return file_apigw_v1_apigw_proto_rawDescGZIP(), []int{1}
-}
-
-// Action verb describing what the RPC does to its target resource(s).
-// Orthogonal to apigw.Operation.method (the HTTP verb); a single gRPC
-// method can be POST + MUTATION_SCOPE_DELETE, etc.
-type MutationScope int32
-
-const (
-	MutationScope_MUTATION_SCOPE_UNSPECIFIED MutationScope = 0
-	MutationScope_MUTATION_SCOPE_READ        MutationScope = 1
-	MutationScope_MUTATION_SCOPE_CREATE      MutationScope = 2
-	MutationScope_MUTATION_SCOPE_UPDATE      MutationScope = 3
-	MutationScope_MUTATION_SCOPE_DELETE      MutationScope = 4
-	// ADMIN covers configuration / policy / governance / role / permission
-	// changes — anything that alters how the system itself behaves, as
-	// opposed to CRUD on tenant-owned data.
-	MutationScope_MUTATION_SCOPE_ADMIN MutationScope = 5
-)
-
-// Enum value maps for MutationScope.
-var (
-	MutationScope_name = map[int32]string{
-		0: "MUTATION_SCOPE_UNSPECIFIED",
-		1: "MUTATION_SCOPE_READ",
-		2: "MUTATION_SCOPE_CREATE",
-		3: "MUTATION_SCOPE_UPDATE",
-		4: "MUTATION_SCOPE_DELETE",
-		5: "MUTATION_SCOPE_ADMIN",
-	}
-	MutationScope_value = map[string]int32{
-		"MUTATION_SCOPE_UNSPECIFIED": 0,
-		"MUTATION_SCOPE_READ":        1,
-		"MUTATION_SCOPE_CREATE":      2,
-		"MUTATION_SCOPE_UPDATE":      3,
-		"MUTATION_SCOPE_DELETE":      4,
-		"MUTATION_SCOPE_ADMIN":       5,
-	}
-)
-
-func (x MutationScope) Enum() *MutationScope {
-	p := new(MutationScope)
-	*p = x
-	return p
-}
-
-func (x MutationScope) String() string {
-	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
-}
-
-func (MutationScope) Descriptor() protoreflect.EnumDescriptor {
-	return file_apigw_v1_apigw_proto_enumTypes[2].Descriptor()
-}
-
-func (MutationScope) Type() protoreflect.EnumType {
-	return &file_apigw_v1_apigw_proto_enumTypes[2]
-}
-
-func (x MutationScope) Number() protoreflect.EnumNumber {
-	return protoreflect.EnumNumber(x)
-}
-
-// Deprecated: Use MutationScope.Descriptor instead.
-func (MutationScope) EnumDescriptor() ([]byte, []int) {
-	return file_apigw_v1_apigw_proto_rawDescGZIP(), []int{2}
-}
-
-// Default user-experience gate for the AI-guardrail policy engine when a
-// call matches this RPC. Customer policy may override (e.g. promote AUTO
-// to CONFIRM for sensitive tenants) but cannot soften below the tier the
-// author declared.
-type DefaultTier int32
-
-const (
-	DefaultTier_DEFAULT_TIER_UNSPECIFIED DefaultTier = 0
-	// Proceed without user prompt.
-	DefaultTier_DEFAULT_TIER_AUTO DefaultTier = 1
-	// Surface a one-click confirmation prompt before execution.
-	DefaultTier_DEFAULT_TIER_CONFIRM DefaultTier = 2
-	// Require a human approver (ticket / approval workflow) before execution.
-	DefaultTier_DEFAULT_TIER_APPROVE DefaultTier = 3
-)
-
-// Enum value maps for DefaultTier.
-var (
-	DefaultTier_name = map[int32]string{
-		0: "DEFAULT_TIER_UNSPECIFIED",
-		1: "DEFAULT_TIER_AUTO",
-		2: "DEFAULT_TIER_CONFIRM",
-		3: "DEFAULT_TIER_APPROVE",
-	}
-	DefaultTier_value = map[string]int32{
-		"DEFAULT_TIER_UNSPECIFIED": 0,
-		"DEFAULT_TIER_AUTO":        1,
-		"DEFAULT_TIER_CONFIRM":     2,
-		"DEFAULT_TIER_APPROVE":     3,
-	}
-)
-
-func (x DefaultTier) Enum() *DefaultTier {
-	p := new(DefaultTier)
-	*p = x
-	return p
-}
-
-func (x DefaultTier) String() string {
-	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
-}
-
-func (DefaultTier) Descriptor() protoreflect.EnumDescriptor {
-	return file_apigw_v1_apigw_proto_enumTypes[3].Descriptor()
-}
-
-func (DefaultTier) Type() protoreflect.EnumType {
-	return &file_apigw_v1_apigw_proto_enumTypes[3]
-}
-
-func (x DefaultTier) Number() protoreflect.EnumNumber {
-	return protoreflect.EnumNumber(x)
-}
-
-// Deprecated: Use DefaultTier.Descriptor instead.
-func (DefaultTier) EnumDescriptor() ([]byte, []int) {
-	return file_apigw_v1_apigw_proto_rawDescGZIP(), []int{3}
 }
 
 type TerraformEntity_TerraformEntityMethodType int32
@@ -298,11 +174,11 @@ func (x TerraformEntity_TerraformEntityMethodType) String() string {
 }
 
 func (TerraformEntity_TerraformEntityMethodType) Descriptor() protoreflect.EnumDescriptor {
-	return file_apigw_v1_apigw_proto_enumTypes[4].Descriptor()
+	return file_apigw_v1_apigw_proto_enumTypes[2].Descriptor()
 }
 
 func (TerraformEntity_TerraformEntityMethodType) Type() protoreflect.EnumType {
-	return &file_apigw_v1_apigw_proto_enumTypes[4]
+	return &file_apigw_v1_apigw_proto_enumTypes[2]
 }
 
 func (x TerraformEntity_TerraformEntityMethodType) Number() protoreflect.EnumNumber {
@@ -349,11 +225,11 @@ func (x TerraformEntity_OptionalExclusion) String() string {
 }
 
 func (TerraformEntity_OptionalExclusion) Descriptor() protoreflect.EnumDescriptor {
-	return file_apigw_v1_apigw_proto_enumTypes[5].Descriptor()
+	return file_apigw_v1_apigw_proto_enumTypes[3].Descriptor()
 }
 
 func (TerraformEntity_OptionalExclusion) Type() protoreflect.EnumType {
-	return &file_apigw_v1_apigw_proto_enumTypes[5]
+	return &file_apigw_v1_apigw_proto_enumTypes[3]
 }
 
 func (x TerraformEntity_OptionalExclusion) Number() protoreflect.EnumNumber {
@@ -395,11 +271,11 @@ func (x Pagination_TerraformEntityPaginationType) String() string {
 }
 
 func (Pagination_TerraformEntityPaginationType) Descriptor() protoreflect.EnumDescriptor {
-	return file_apigw_v1_apigw_proto_enumTypes[6].Descriptor()
+	return file_apigw_v1_apigw_proto_enumTypes[4].Descriptor()
 }
 
 func (Pagination_TerraformEntityPaginationType) Type() protoreflect.EnumType {
-	return &file_apigw_v1_apigw_proto_enumTypes[6]
+	return &file_apigw_v1_apigw_proto_enumTypes[4]
 }
 
 func (x Pagination_TerraformEntityPaginationType) Number() protoreflect.EnumNumber {
@@ -441,11 +317,11 @@ func (x PaginationInput_TerraformEntityPaginationInputIn) String() string {
 }
 
 func (PaginationInput_TerraformEntityPaginationInputIn) Descriptor() protoreflect.EnumDescriptor {
-	return file_apigw_v1_apigw_proto_enumTypes[7].Descriptor()
+	return file_apigw_v1_apigw_proto_enumTypes[5].Descriptor()
 }
 
 func (PaginationInput_TerraformEntityPaginationInputIn) Type() protoreflect.EnumType {
-	return &file_apigw_v1_apigw_proto_enumTypes[7]
+	return &file_apigw_v1_apigw_proto_enumTypes[5]
 }
 
 func (x PaginationInput_TerraformEntityPaginationInputIn) Number() protoreflect.EnumNumber {
@@ -487,11 +363,11 @@ func (x PaginationInput_TerraformEntityPaginationInputType) String() string {
 }
 
 func (PaginationInput_TerraformEntityPaginationInputType) Descriptor() protoreflect.EnumDescriptor {
-	return file_apigw_v1_apigw_proto_enumTypes[8].Descriptor()
+	return file_apigw_v1_apigw_proto_enumTypes[6].Descriptor()
 }
 
 func (PaginationInput_TerraformEntityPaginationInputType) Type() protoreflect.EnumType {
-	return &file_apigw_v1_apigw_proto_enumTypes[8]
+	return &file_apigw_v1_apigw_proto_enumTypes[6]
 }
 
 func (x PaginationInput_TerraformEntityPaginationInputType) Number() protoreflect.EnumNumber {
@@ -802,16 +678,11 @@ func (x *Deprecation) GetSunsetDate() string {
 type MethodOptions struct {
 	state      protoimpl.MessageState `protogen:"open.v1"`
 	Operations []*Operation           `protobuf:"bytes,1,rep,name=operations,proto3" json:"operations,omitempty"`
-	// delegation carries per-RPC AI-guardrail tags. Describes the intrinsic
-	// risk shape of the RPC, independent of the route(s) under operations[]
-	// that expose it. Consumed by the lethal-trifecta translator in c1's
-	// pkg/aigov/derive to produce per-turn capability scores.
-	//
-	// Field names and numbers in DelegationMeta mirror
-	// bundle.v1.DelegationMeta in ductone/mcp-axiomatic so a single
-	// translator can consume either surface. mcp-axiomatic encodes
-	// equivalent values as strings (parsed by the translator); apigw uses
-	// typed enums directly.
+	// delegation carries per-RPC AI-guardrail tags describing the
+	// intrinsic risk shape of the RPC, independent of the route(s) under
+	// operations[] that expose it. Consumed by the lethal-trifecta
+	// translator in c1's pkg/aigov/derive to produce per-turn capability
+	// scores.
 	Delegation    *DelegationMeta `protobuf:"bytes,2,opt,name=delegation,proto3" json:"delegation,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -863,34 +734,19 @@ func (x *MethodOptions) GetDelegation() *DelegationMeta {
 
 type DelegationMeta struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Worst-case severity if this RPC is misused or its output exfiltrated.
-	// Aligned with NIST FIPS 199; CRITICAL is reserved for incident-grade
-	// risk (e.g. raw credential read, mass user delete).
-	RiskLevel Severity `protobuf:"varint,1,opt,name=risk_level,json=riskLevel,proto3,enum=apigw.v1.Severity" json:"risk_level,omitempty"`
-	// Default UX gating tier. AUTO / CONFIRM / APPROVE roughly correspond to
-	// "auto-execute", "ask first", and "needs human ticket".
-	DefaultTier DefaultTier `protobuf:"varint,2,opt,name=default_tier,json=defaultTier,proto3,enum=apigw.v1.DefaultTier" json:"default_tier,omitempty"`
-	// Whether the action can be undone by a counter-operation in the same
-	// tenant (e.g. DeleteX reversible by CreateX with the same id). Unset
-	// means unknown — caller should treat as not reversible.
-	Reversible bool `protobuf:"varint,3,opt,name=reversible,proto3" json:"reversible,omitempty"`
-	// Action verb the RPC performs; see MutationScope.
-	MutationScope MutationScope `protobuf:"varint,4,opt,name=mutation_scope,json=mutationScope,proto3,enum=apigw.v1.MutationScope" json:"mutation_scope,omitempty"`
-	// Free-form sensitivity tags consumed by downstream translators. Two
-	// categories of tag are accepted on the same list:
-	//   - Data category: "pii", "secrets", "financial", "production",
-	//     "lifecycle" (the common mcp-axiomatic vocabulary).
-	//   - Channel / side-effect markers: e.g. "outbound" (the RPC reaches
-	//     out to an external system), "untrusted_output" (the RPC returns
-	//     attacker-influenceable content that should be stamped untrusted
-	//     when ingested into agent context).
-	//
-	// The vocabulary is intentionally open; downstream consumers validate
-	// against the set they know and warn on unknown values. Standardization
-	// of channel/side-effect markers is tracked as follow-up.
-	SensitivityTags []string `protobuf:"bytes,5,rep,name=sensitivity_tags,json=sensitivityTags,proto3" json:"sensitivity_tags,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	// privacy_class scores the trifecta cube's Axis 1 (Private Data Access)
+	// contribution from this RPC: how sensitive is the data the RPC reads
+	// and returns. Internal-only / public reads leave UNSPECIFIED. The
+	// policy engine reads this directly as the A1 input.
+	PrivacyClass Severity `protobuf:"varint,1,opt,name=privacy_class,json=privacyClass,proto3,enum=apigw.v1.Severity" json:"privacy_class,omitempty"`
+	// exfil_class scores the trifecta cube's Axis 3 (Exfiltration)
+	// contribution from this RPC: how exfil-friendly is the outbound
+	// channel this RPC can reach. Internal-only RPCs leave UNSPECIFIED;
+	// anything UNSPECIFIED implies no outbound channel. The policy engine
+	// reads this directly as the A3 input.
+	ExfilClass    Severity `protobuf:"varint,2,opt,name=exfil_class,json=exfilClass,proto3,enum=apigw.v1.Severity" json:"exfil_class,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *DelegationMeta) Reset() {
@@ -923,39 +779,18 @@ func (*DelegationMeta) Descriptor() ([]byte, []int) {
 	return file_apigw_v1_apigw_proto_rawDescGZIP(), []int{6}
 }
 
-func (x *DelegationMeta) GetRiskLevel() Severity {
+func (x *DelegationMeta) GetPrivacyClass() Severity {
 	if x != nil {
-		return x.RiskLevel
+		return x.PrivacyClass
 	}
 	return Severity_SEVERITY_UNSPECIFIED
 }
 
-func (x *DelegationMeta) GetDefaultTier() DefaultTier {
+func (x *DelegationMeta) GetExfilClass() Severity {
 	if x != nil {
-		return x.DefaultTier
+		return x.ExfilClass
 	}
-	return DefaultTier_DEFAULT_TIER_UNSPECIFIED
-}
-
-func (x *DelegationMeta) GetReversible() bool {
-	if x != nil {
-		return x.Reversible
-	}
-	return false
-}
-
-func (x *DelegationMeta) GetMutationScope() MutationScope {
-	if x != nil {
-		return x.MutationScope
-	}
-	return MutationScope_MUTATION_SCOPE_UNSPECIFIED
-}
-
-func (x *DelegationMeta) GetSensitivityTags() []string {
-	if x != nil {
-		return x.SensitivityTags
-	}
-	return nil
+	return Severity_SEVERITY_UNSPECIFIED
 }
 
 type ServiceOptions struct {
@@ -1664,16 +1499,11 @@ const file_apigw_v1_apigw_proto_rawDesc = "" +
 	"operations\x128\n" +
 	"\n" +
 	"delegation\x18\x02 \x01(\v2\x18.apigw.v1.DelegationMetaR\n" +
-	"delegation\"\x88\x02\n" +
-	"\x0eDelegationMeta\x121\n" +
-	"\n" +
-	"risk_level\x18\x01 \x01(\x0e2\x12.apigw.v1.SeverityR\triskLevel\x128\n" +
-	"\fdefault_tier\x18\x02 \x01(\x0e2\x15.apigw.v1.DefaultTierR\vdefaultTier\x12\x1e\n" +
-	"\n" +
-	"reversible\x18\x03 \x01(\bR\n" +
-	"reversible\x12>\n" +
-	"\x0emutation_scope\x18\x04 \x01(\x0e2\x17.apigw.v1.MutationScopeR\rmutationScope\x12)\n" +
-	"\x10sensitivity_tags\x18\x05 \x03(\tR\x0fsensitivityTags\"=\n" +
+	"delegation\"~\n" +
+	"\x0eDelegationMeta\x127\n" +
+	"\rprivacy_class\x18\x01 \x01(\x0e2\x12.apigw.v1.SeverityR\fprivacyClass\x123\n" +
+	"\vexfil_class\x18\x02 \x01(\x0e2\x12.apigw.v1.SeverityR\n" +
+	"exfilClass\"=\n" +
 	"\x0eServiceOptions\x12+\n" +
 	"\aservice\x18\x01 \x01(\v2\x11.apigw.v1.ServiceR\aservice\"\xb9\x01\n" +
 	"\aService\x121\n" +
@@ -1751,25 +1581,12 @@ const file_apigw_v1_apigw_proto_rawDesc = "" +
 	"\x0fSTABILITY_DRAFT\x10\x01\x12\x13\n" +
 	"\x0fSTABILITY_ALPHA\x10\x02\x12\x12\n" +
 	"\x0eSTABILITY_BETA\x10\x03\x12\x14\n" +
-	"\x10STABILITY_STABLE\x10\x04*u\n" +
+	"\x10STABILITY_STABLE\x10\x04*^\n" +
 	"\bSeverity\x12\x18\n" +
 	"\x14SEVERITY_UNSPECIFIED\x10\x00\x12\x10\n" +
 	"\fSEVERITY_LOW\x10\x01\x12\x13\n" +
 	"\x0fSEVERITY_MEDIUM\x10\x02\x12\x11\n" +
-	"\rSEVERITY_HIGH\x10\x03\x12\x15\n" +
-	"\x11SEVERITY_CRITICAL\x10\x04*\xb3\x01\n" +
-	"\rMutationScope\x12\x1e\n" +
-	"\x1aMUTATION_SCOPE_UNSPECIFIED\x10\x00\x12\x17\n" +
-	"\x13MUTATION_SCOPE_READ\x10\x01\x12\x19\n" +
-	"\x15MUTATION_SCOPE_CREATE\x10\x02\x12\x19\n" +
-	"\x15MUTATION_SCOPE_UPDATE\x10\x03\x12\x19\n" +
-	"\x15MUTATION_SCOPE_DELETE\x10\x04\x12\x18\n" +
-	"\x14MUTATION_SCOPE_ADMIN\x10\x05*v\n" +
-	"\vDefaultTier\x12\x1c\n" +
-	"\x18DEFAULT_TIER_UNSPECIFIED\x10\x00\x12\x15\n" +
-	"\x11DEFAULT_TIER_AUTO\x10\x01\x12\x18\n" +
-	"\x14DEFAULT_TIER_CONFIRM\x10\x02\x12\x18\n" +
-	"\x14DEFAULT_TIER_APPROVE\x10\x03:T\n" +
+	"\rSEVERITY_HIGH\x10\x03:T\n" +
 	"\aservice\x12\x1f.google.protobuf.ServiceOptions\x18\xe2; \x01(\v2\x18.apigw.v1.ServiceOptionsR\aservice:P\n" +
 	"\x06method\x12\x1e.google.protobuf.MethodOptions\x18\xe3; \x01(\v2\x17.apigw.v1.MethodOptionsR\x06method:L\n" +
 	"\x05field\x12\x1d.google.protobuf.FieldOptions\x18\xe4; \x01(\v2\x16.apigw.v1.FieldOptionsR\x05field:T\n" +
@@ -1789,81 +1606,78 @@ func file_apigw_v1_apigw_proto_rawDescGZIP() []byte {
 	return file_apigw_v1_apigw_proto_rawDescData
 }
 
-var file_apigw_v1_apigw_proto_enumTypes = make([]protoimpl.EnumInfo, 9)
+var file_apigw_v1_apigw_proto_enumTypes = make([]protoimpl.EnumInfo, 7)
 var file_apigw_v1_apigw_proto_msgTypes = make([]protoimpl.MessageInfo, 17)
 var file_apigw_v1_apigw_proto_goTypes = []any{
-	(Stability)(0),     // 0: apigw.v1.Stability
-	(Severity)(0),      // 1: apigw.v1.Severity
-	(MutationScope)(0), // 2: apigw.v1.MutationScope
-	(DefaultTier)(0),   // 3: apigw.v1.DefaultTier
-	(TerraformEntity_TerraformEntityMethodType)(0),          // 4: apigw.v1.TerraformEntity.TerraformEntityMethodType
-	(TerraformEntity_OptionalExclusion)(0),                  // 5: apigw.v1.TerraformEntity.OptionalExclusion
-	(Pagination_TerraformEntityPaginationType)(0),           // 6: apigw.v1.Pagination.TerraformEntityPaginationType
-	(PaginationInput_TerraformEntityPaginationInputIn)(0),   // 7: apigw.v1.PaginationInput.TerraformEntityPaginationInputIn
-	(PaginationInput_TerraformEntityPaginationInputType)(0), // 8: apigw.v1.PaginationInput.TerraformEntityPaginationInputType
-	(*MessageOptions)(nil),                                  // 9: apigw.v1.MessageOptions
-	(*MessageOption)(nil),                                   // 10: apigw.v1.MessageOption
-	(*FieldOption)(nil),                                     // 11: apigw.v1.FieldOption
-	(*FieldOptions)(nil),                                    // 12: apigw.v1.FieldOptions
-	(*Deprecation)(nil),                                     // 13: apigw.v1.Deprecation
-	(*MethodOptions)(nil),                                   // 14: apigw.v1.MethodOptions
-	(*DelegationMeta)(nil),                                  // 15: apigw.v1.DelegationMeta
-	(*ServiceOptions)(nil),                                  // 16: apigw.v1.ServiceOptions
-	(*Service)(nil),                                         // 17: apigw.v1.Service
-	(*TerraformEntity)(nil),                                 // 18: apigw.v1.TerraformEntity
-	(*Pagination)(nil),                                      // 19: apigw.v1.Pagination
-	(*PaginationInput)(nil),                                 // 20: apigw.v1.PaginationInput
-	(*PaginationOutput)(nil),                                // 21: apigw.v1.PaginationOutput
-	(*Operation)(nil),                                       // 22: apigw.v1.Operation
-	(*RequestExample)(nil),                                  // 23: apigw.v1.RequestExample
-	(*ResponseExample)(nil),                                 // 24: apigw.v1.ResponseExample
-	nil,                                                     // 25: apigw.v1.Operation.QueryEntry
-	(*descriptorpb.ServiceOptions)(nil),                     // 26: google.protobuf.ServiceOptions
-	(*descriptorpb.MethodOptions)(nil),                      // 27: google.protobuf.MethodOptions
-	(*descriptorpb.FieldOptions)(nil),                       // 28: google.protobuf.FieldOptions
-	(*descriptorpb.MessageOptions)(nil),                     // 29: google.protobuf.MessageOptions
+	(Stability)(0), // 0: apigw.v1.Stability
+	(Severity)(0),  // 1: apigw.v1.Severity
+	(TerraformEntity_TerraformEntityMethodType)(0),          // 2: apigw.v1.TerraformEntity.TerraformEntityMethodType
+	(TerraformEntity_OptionalExclusion)(0),                  // 3: apigw.v1.TerraformEntity.OptionalExclusion
+	(Pagination_TerraformEntityPaginationType)(0),           // 4: apigw.v1.Pagination.TerraformEntityPaginationType
+	(PaginationInput_TerraformEntityPaginationInputIn)(0),   // 5: apigw.v1.PaginationInput.TerraformEntityPaginationInputIn
+	(PaginationInput_TerraformEntityPaginationInputType)(0), // 6: apigw.v1.PaginationInput.TerraformEntityPaginationInputType
+	(*MessageOptions)(nil),                                  // 7: apigw.v1.MessageOptions
+	(*MessageOption)(nil),                                   // 8: apigw.v1.MessageOption
+	(*FieldOption)(nil),                                     // 9: apigw.v1.FieldOption
+	(*FieldOptions)(nil),                                    // 10: apigw.v1.FieldOptions
+	(*Deprecation)(nil),                                     // 11: apigw.v1.Deprecation
+	(*MethodOptions)(nil),                                   // 12: apigw.v1.MethodOptions
+	(*DelegationMeta)(nil),                                  // 13: apigw.v1.DelegationMeta
+	(*ServiceOptions)(nil),                                  // 14: apigw.v1.ServiceOptions
+	(*Service)(nil),                                         // 15: apigw.v1.Service
+	(*TerraformEntity)(nil),                                 // 16: apigw.v1.TerraformEntity
+	(*Pagination)(nil),                                      // 17: apigw.v1.Pagination
+	(*PaginationInput)(nil),                                 // 18: apigw.v1.PaginationInput
+	(*PaginationOutput)(nil),                                // 19: apigw.v1.PaginationOutput
+	(*Operation)(nil),                                       // 20: apigw.v1.Operation
+	(*RequestExample)(nil),                                  // 21: apigw.v1.RequestExample
+	(*ResponseExample)(nil),                                 // 22: apigw.v1.ResponseExample
+	nil,                                                     // 23: apigw.v1.Operation.QueryEntry
+	(*descriptorpb.ServiceOptions)(nil),                     // 24: google.protobuf.ServiceOptions
+	(*descriptorpb.MethodOptions)(nil),                      // 25: google.protobuf.MethodOptions
+	(*descriptorpb.FieldOptions)(nil),                       // 26: google.protobuf.FieldOptions
+	(*descriptorpb.MessageOptions)(nil),                     // 27: google.protobuf.MessageOptions
 }
 var file_apigw_v1_apigw_proto_depIdxs = []int32{
-	10, // 0: apigw.v1.MessageOptions.message_options:type_name -> apigw.v1.MessageOption
-	18, // 1: apigw.v1.MessageOption.terraform_entity:type_name -> apigw.v1.TerraformEntity
+	8,  // 0: apigw.v1.MessageOptions.message_options:type_name -> apigw.v1.MessageOption
+	16, // 1: apigw.v1.MessageOption.terraform_entity:type_name -> apigw.v1.TerraformEntity
 	0,  // 2: apigw.v1.FieldOption.stability:type_name -> apigw.v1.Stability
-	13, // 3: apigw.v1.FieldOption.deprecation:type_name -> apigw.v1.Deprecation
-	11, // 4: apigw.v1.FieldOptions.field_options:type_name -> apigw.v1.FieldOption
-	22, // 5: apigw.v1.MethodOptions.operations:type_name -> apigw.v1.Operation
-	15, // 6: apigw.v1.MethodOptions.delegation:type_name -> apigw.v1.DelegationMeta
-	1,  // 7: apigw.v1.DelegationMeta.risk_level:type_name -> apigw.v1.Severity
-	3,  // 8: apigw.v1.DelegationMeta.default_tier:type_name -> apigw.v1.DefaultTier
-	2,  // 9: apigw.v1.DelegationMeta.mutation_scope:type_name -> apigw.v1.MutationScope
-	17, // 10: apigw.v1.ServiceOptions.service:type_name -> apigw.v1.Service
-	0,  // 11: apigw.v1.Service.stability:type_name -> apigw.v1.Stability
-	13, // 12: apigw.v1.Service.deprecation:type_name -> apigw.v1.Deprecation
-	4,  // 13: apigw.v1.TerraformEntity.type:type_name -> apigw.v1.TerraformEntity.TerraformEntityMethodType
-	5,  // 14: apigw.v1.TerraformEntity.optional_exclusion:type_name -> apigw.v1.TerraformEntity.OptionalExclusion
-	6,  // 15: apigw.v1.Pagination.type:type_name -> apigw.v1.Pagination.TerraformEntityPaginationType
-	20, // 16: apigw.v1.Pagination.inputs:type_name -> apigw.v1.PaginationInput
-	21, // 17: apigw.v1.Pagination.outputs:type_name -> apigw.v1.PaginationOutput
-	7,  // 18: apigw.v1.PaginationInput.in:type_name -> apigw.v1.PaginationInput.TerraformEntityPaginationInputIn
-	8,  // 19: apigw.v1.PaginationInput.type:type_name -> apigw.v1.PaginationInput.TerraformEntityPaginationInputType
-	25, // 20: apigw.v1.Operation.query:type_name -> apigw.v1.Operation.QueryEntry
-	0,  // 21: apigw.v1.Operation.stability:type_name -> apigw.v1.Stability
-	23, // 22: apigw.v1.Operation.request_examples:type_name -> apigw.v1.RequestExample
-	24, // 23: apigw.v1.Operation.response_examples:type_name -> apigw.v1.ResponseExample
-	18, // 24: apigw.v1.Operation.terraform_entity:type_name -> apigw.v1.TerraformEntity
-	19, // 25: apigw.v1.Operation.pagination:type_name -> apigw.v1.Pagination
-	13, // 26: apigw.v1.Operation.deprecation:type_name -> apigw.v1.Deprecation
-	26, // 27: apigw.v1.service:extendee -> google.protobuf.ServiceOptions
-	27, // 28: apigw.v1.method:extendee -> google.protobuf.MethodOptions
-	28, // 29: apigw.v1.field:extendee -> google.protobuf.FieldOptions
-	29, // 30: apigw.v1.message:extendee -> google.protobuf.MessageOptions
-	16, // 31: apigw.v1.service:type_name -> apigw.v1.ServiceOptions
-	14, // 32: apigw.v1.method:type_name -> apigw.v1.MethodOptions
-	12, // 33: apigw.v1.field:type_name -> apigw.v1.FieldOptions
-	9,  // 34: apigw.v1.message:type_name -> apigw.v1.MessageOptions
-	35, // [35:35] is the sub-list for method output_type
-	35, // [35:35] is the sub-list for method input_type
-	31, // [31:35] is the sub-list for extension type_name
-	27, // [27:31] is the sub-list for extension extendee
-	0,  // [0:27] is the sub-list for field type_name
+	11, // 3: apigw.v1.FieldOption.deprecation:type_name -> apigw.v1.Deprecation
+	9,  // 4: apigw.v1.FieldOptions.field_options:type_name -> apigw.v1.FieldOption
+	20, // 5: apigw.v1.MethodOptions.operations:type_name -> apigw.v1.Operation
+	13, // 6: apigw.v1.MethodOptions.delegation:type_name -> apigw.v1.DelegationMeta
+	1,  // 7: apigw.v1.DelegationMeta.privacy_class:type_name -> apigw.v1.Severity
+	1,  // 8: apigw.v1.DelegationMeta.exfil_class:type_name -> apigw.v1.Severity
+	15, // 9: apigw.v1.ServiceOptions.service:type_name -> apigw.v1.Service
+	0,  // 10: apigw.v1.Service.stability:type_name -> apigw.v1.Stability
+	11, // 11: apigw.v1.Service.deprecation:type_name -> apigw.v1.Deprecation
+	2,  // 12: apigw.v1.TerraformEntity.type:type_name -> apigw.v1.TerraformEntity.TerraformEntityMethodType
+	3,  // 13: apigw.v1.TerraformEntity.optional_exclusion:type_name -> apigw.v1.TerraformEntity.OptionalExclusion
+	4,  // 14: apigw.v1.Pagination.type:type_name -> apigw.v1.Pagination.TerraformEntityPaginationType
+	18, // 15: apigw.v1.Pagination.inputs:type_name -> apigw.v1.PaginationInput
+	19, // 16: apigw.v1.Pagination.outputs:type_name -> apigw.v1.PaginationOutput
+	5,  // 17: apigw.v1.PaginationInput.in:type_name -> apigw.v1.PaginationInput.TerraformEntityPaginationInputIn
+	6,  // 18: apigw.v1.PaginationInput.type:type_name -> apigw.v1.PaginationInput.TerraformEntityPaginationInputType
+	23, // 19: apigw.v1.Operation.query:type_name -> apigw.v1.Operation.QueryEntry
+	0,  // 20: apigw.v1.Operation.stability:type_name -> apigw.v1.Stability
+	21, // 21: apigw.v1.Operation.request_examples:type_name -> apigw.v1.RequestExample
+	22, // 22: apigw.v1.Operation.response_examples:type_name -> apigw.v1.ResponseExample
+	16, // 23: apigw.v1.Operation.terraform_entity:type_name -> apigw.v1.TerraformEntity
+	17, // 24: apigw.v1.Operation.pagination:type_name -> apigw.v1.Pagination
+	11, // 25: apigw.v1.Operation.deprecation:type_name -> apigw.v1.Deprecation
+	24, // 26: apigw.v1.service:extendee -> google.protobuf.ServiceOptions
+	25, // 27: apigw.v1.method:extendee -> google.protobuf.MethodOptions
+	26, // 28: apigw.v1.field:extendee -> google.protobuf.FieldOptions
+	27, // 29: apigw.v1.message:extendee -> google.protobuf.MessageOptions
+	14, // 30: apigw.v1.service:type_name -> apigw.v1.ServiceOptions
+	12, // 31: apigw.v1.method:type_name -> apigw.v1.MethodOptions
+	10, // 32: apigw.v1.field:type_name -> apigw.v1.FieldOptions
+	7,  // 33: apigw.v1.message:type_name -> apigw.v1.MessageOptions
+	34, // [34:34] is the sub-list for method output_type
+	34, // [34:34] is the sub-list for method input_type
+	30, // [30:34] is the sub-list for extension type_name
+	26, // [26:30] is the sub-list for extension extendee
+	0,  // [0:26] is the sub-list for field type_name
 }
 
 func init() { file_apigw_v1_apigw_proto_init() }
@@ -1876,7 +1690,7 @@ func file_apigw_v1_apigw_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_apigw_v1_apigw_proto_rawDesc), len(file_apigw_v1_apigw_proto_rawDesc)),
-			NumEnums:      9,
+			NumEnums:      7,
 			NumMessages:   17,
 			NumExtensions: 4,
 			NumServices:   0,


### PR DESCRIPTION
## Summary

Brings `apigw/v1/apigw.pb.go` back into sync with the released `.proto`. Cuts a follow-up release (v0.6.4) after merge.

## The bug in v0.6.3

[v0.6.3](https://github.com/ductone/protoc-gen-apigw/releases/tag/v0.6.3) (PR #81 merge) shipped an internally inconsistent release:

| Artifact in v0.6.3 | Schema |
|---|---|
| `protos/apigw/v1/apigw.proto` | **Narrow** — `Severity{LOW/MED/HIGH}`, `DelegationMeta{privacy_class, exfil_class}` |
| `apigw/v1/apigw.pb.go` (generated) | **Broad** — `Severity{LOW/MED/HIGH/CRITICAL}`, `MutationScope`, `DefaultTier`, `DelegationMeta{risk_level, default_tier, reversible, mutation_scope, sensitivity_tags}` |

The .pb.go was generated from an intermediate state during PR #81 and never regenerated after the final trim commits (`26c8144`, `710ad11`, `ddee799`). The merge squashed the inconsistency into the release.

## Wire-level consequence for consumers

Downstream consumers pinning v0.6.3 (e.g. [ductone/c1#19725](https://github.com/ductone/c1/pull/19725)) hit a real wire-level mismatch:

> An annotation `delegation { exfil_class: SEVERITY_HIGH }` written against the .proto (field 2 = `Severity`) is decoded by the linked v0.6.3 runtime as `default_tier` (field 2 = `DefaultTier`). `SEVERITY_CRITICAL=4` is unrepresentable on the consumer side.

Caught by the c1 PR's github-actions reviewer.

## What this PR does

Single change: regenerate `apigw/v1/apigw.pb.go` from the current `.proto` via `make generate`. Diff is mechanical — 300 deletions (removed broad-schema types) + 114 insertions (clean narrow-schema bindings).

Tests pass (`go test ./...`).

## Follow-ups (separate PRs)

1. Tag **v0.6.4** at this merge commit.
2. Bump c1#19725's `go.mod` to v0.6.4 and re-sync the vendored `.proto` (it'll be the narrow schema, again — consistent with both the upstream `.proto` and the regenerated `.pb.go`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)